### PR TITLE
Modified meta-model and example model

### DIFF
--- a/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign
+++ b/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign
@@ -80,7 +80,7 @@
             <viewVariable name="containerView"/>
             <initialOperation>
               <firstModelOperations xsi:type="tool_1:ChangeContext" browseExpression="var:container">
-                <subModelOperations xsi:type="tool_1:CreateInstance" typeName="GenHandle" referenceName="elements"/>
+                <subModelOperations xsi:type="tool_1:CreateInstance" typeName="GenHandle" referenceName="machines"/>
               </firstModelOperations>
             </initialOperation>
           </ownedTools>
@@ -89,7 +89,7 @@
             <viewVariable name="containerView"/>
             <initialOperation>
               <firstModelOperations xsi:type="tool_1:ChangeContext" browseExpression="var:container">
-                <subModelOperations xsi:type="tool_1:CreateInstance" typeName="GenHead" referenceName="elements"/>
+                <subModelOperations xsi:type="tool_1:CreateInstance" typeName="GenHead" referenceName="machines"/>
               </firstModelOperations>
             </initialOperation>
           </ownedTools>
@@ -98,7 +98,7 @@
             <viewVariable name="containerView"/>
             <initialOperation>
               <firstModelOperations xsi:type="tool_1:ChangeContext" browseExpression="var:container">
-                <subModelOperations xsi:type="tool_1:CreateInstance" typeName="Assembler" referenceName="elements"/>
+                <subModelOperations xsi:type="tool_1:CreateInstance" typeName="Assembler" referenceName="machines"/>
               </firstModelOperations>
             </initialOperation>
           </ownedTools>

--- a/uk.ac.kcl.inf.modelling.pls.example/basic.pls
+++ b/uk.ac.kcl.inf.modelling.pls.example/basic.pls
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pls:ProductionLineModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:pls="https://inf.kcl.ac.uk/models/pls">
-  <elements xsi:type="pls:GenHandle" out="//@elements.3"/>
-  <elements xsi:type="pls:GenHead" out="//@elements.5"/>
-  <elements xsi:type="pls:Assembler" out="//@elements.7" in="//@elements.6"/>
-  <elements xsi:type="pls:Conveyor" name="" parts="//@elements.4" tray="//@elements.6"/>
-  <elements xsi:type="pls:Handle"/>
-  <elements xsi:type="pls:Conveyor" tray="//@elements.6"/>
-  <elements xsi:type="pls:Tray"/>
-  <elements xsi:type="pls:Conveyor" name=""/>
+  <machines xsi:type="pls:GenHandle" out="//@containers.0"/>
+  <machines xsi:type="pls:GenHead" out="//@containers.1"/>
+  <machines xsi:type="pls:Assembler" out="//@containers.3" in="//@containers.2"/>
+  <containers xsi:type="pls:Conveyor" name="" tray="//@containers.2">
+  	<parts xsi:type="pls:Handle"/>
+  </containers>
+  <containers xsi:type="pls:Conveyor" tray="//@containers.2"/>
+  <containers xsi:type="pls:Tray"/>
+  <containers xsi:type="pls:Conveyor" name=""/>
 </pls:ProductionLineModel>

--- a/uk.ac.kcl.inf.modelling.pls.example/representations.aird
+++ b/uk.ac.kcl.inf.modelling.pls.example/representations.aird
@@ -351,309 +351,309 @@
     </ownedAnnotationEntries>
     <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_fIKucJT8Eeqb8f7pGMdPvg" source="GMF_DIAGRAMS">
       <data xmi:type="notation:Diagram" xmi:id="_fIKucZT8Eeqb8f7pGMdPvg" type="Sirius" element="_fHjqcJT8Eeqb8f7pGMdPvg" measurementUnit="Pixel">
-        <children xmi:type="notation:Node" xmi:id="_fIKuc5T8Eeqb8f7pGMdPvg" type="2001" element="_fHk4kJT8Eeqb8f7pGMdPvg">
-          <children xmi:type="notation:Node" xmi:id="_fILVgJT8Eeqb8f7pGMdPvg" type="5002">
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_fILVgZT8Eeqb8f7pGMdPvg" x="-1"/>
+        <children xmi:type="notation:Node" xmi:id="_BYs5IDo1Eeur_rEWBAksIg" type="2001" element="_BW_B4Do1Eeur_rEWBAksIg">
+          <children xmi:type="notation:Node" xmi:id="_BYzm0Do1Eeur_rEWBAksIg" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_BYzm0To1Eeur_rEWBAksIg" x="-1"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_fIQOA5T8Eeqb8f7pGMdPvg" type="3005" element="_fHk4kZT8Eeqb8f7pGMdPvg">
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_fIQOBJT8Eeqb8f7pGMdPvg" fontName="Segoe UI"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIQOBZT8Eeqb8f7pGMdPvg"/>
+          <children xmi:type="notation:Node" xmi:id="_BZN2gDo1Eeur_rEWBAksIg" type="3005" element="_BXEhcDo1Eeur_rEWBAksIg">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_BZN2gTo1Eeur_rEWBAksIg" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZN2gjo1Eeur_rEWBAksIg"/>
           </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_fIKudJT8Eeqb8f7pGMdPvg" fontName="Segoe UI" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIKudZT8Eeqb8f7pGMdPvg" x="101" y="320" width="75" height="69"/>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_BYs5ITo1Eeur_rEWBAksIg" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BYs5Ijo1Eeur_rEWBAksIg" x="84" y="305" width="75" height="69"/>
         </children>
-        <children xmi:type="notation:Node" xmi:id="_fILVgpT8Eeqb8f7pGMdPvg" type="2001" element="_fHnU0ZT8Eeqb8f7pGMdPvg">
-          <children xmi:type="notation:Node" xmi:id="_fIL8kJT8Eeqb8f7pGMdPvg" type="5002">
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_fIL8kZT8Eeqb8f7pGMdPvg" x="-1"/>
+        <children xmi:type="notation:Node" xmi:id="_BY_NADo1Eeur_rEWBAksIg" type="2001" element="_BXGWoTo1Eeur_rEWBAksIg">
+          <children xmi:type="notation:Node" xmi:id="_BY_0EDo1Eeur_rEWBAksIg" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_BY_0ETo1Eeur_rEWBAksIg" x="-1"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_fIQOBpT8Eeqb8f7pGMdPvg" type="3005" element="_fHn74JT8Eeqb8f7pGMdPvg">
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_fIQOB5T8Eeqb8f7pGMdPvg" fontName="Segoe UI"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIQOCJT8Eeqb8f7pGMdPvg"/>
+          <children xmi:type="notation:Node" xmi:id="_BZPEoDo1Eeur_rEWBAksIg" type="3005" element="_BXG9sDo1Eeur_rEWBAksIg">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_BZPEoTo1Eeur_rEWBAksIg" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZPEojo1Eeur_rEWBAksIg"/>
           </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_fILVg5T8Eeqb8f7pGMdPvg" fontName="Segoe UI" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fILVhJT8Eeqb8f7pGMdPvg" x="106" y="164" width="65" height="67"/>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_BY_NATo1Eeur_rEWBAksIg" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BY_NAjo1Eeur_rEWBAksIg" x="84" y="162" width="65" height="67"/>
         </children>
-        <children xmi:type="notation:Node" xmi:id="_fIL8kpT8Eeqb8f7pGMdPvg" type="2001" element="_fHn74pT8Eeqb8f7pGMdPvg">
-          <children xmi:type="notation:Node" xmi:id="_fIL8lZT8Eeqb8f7pGMdPvg" type="5002">
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_fIL8lpT8Eeqb8f7pGMdPvg" y="5"/>
+        <children xmi:type="notation:Node" xmi:id="_BZBpQDo1Eeur_rEWBAksIg" type="2001" element="_BXG9sjo1Eeur_rEWBAksIg">
+          <children xmi:type="notation:Node" xmi:id="_BZDecDo1Eeur_rEWBAksIg" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_BZDecTo1Eeur_rEWBAksIg" y="5"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_fIQ1EJT8Eeqb8f7pGMdPvg" type="3005" element="_fHn745T8Eeqb8f7pGMdPvg">
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_fIQ1EZT8Eeqb8f7pGMdPvg" fontName="Segoe UI"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIQ1EpT8Eeqb8f7pGMdPvg"/>
+          <children xmi:type="notation:Node" xmi:id="_BZPrsDo1Eeur_rEWBAksIg" type="3005" element="_BXHkwDo1Eeur_rEWBAksIg">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_BZPrsTo1Eeur_rEWBAksIg" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZPrsjo1Eeur_rEWBAksIg"/>
           </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_fIL8k5T8Eeqb8f7pGMdPvg" fontName="Segoe UI" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIL8lJT8Eeqb8f7pGMdPvg" x="610" y="221" width="70" height="60"/>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_BZBpQTo1Eeur_rEWBAksIg" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZBpQjo1Eeur_rEWBAksIg" x="705" y="210" width="70" height="60"/>
         </children>
-        <children xmi:type="notation:Node" xmi:id="_fIMjoJT8Eeqb8f7pGMdPvg" type="2003" element="_fHoi8JT8Eeqb8f7pGMdPvg">
-          <children xmi:type="notation:Node" xmi:id="_fIMjo5T8Eeqb8f7pGMdPvg" type="5007"/>
-          <children xmi:type="notation:Node" xmi:id="_fIMjpJT8Eeqb8f7pGMdPvg" type="7004">
-            <children xmi:type="notation:Node" xmi:id="_fIQ1E5T8Eeqb8f7pGMdPvg" type="3010" element="_fHpKAJT8Eeqb8f7pGMdPvg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_fIQ1FJT8Eeqb8f7pGMdPvg" fontName="Segoe UI" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_fIQ1FZT8Eeqb8f7pGMdPvg"/>
+        <children xmi:type="notation:Node" xmi:id="_BZGhwDo1Eeur_rEWBAksIg" type="2003" element="_BXIy4Do1Eeur_rEWBAksIg">
+          <children xmi:type="notation:Node" xmi:id="_BZHI0Do1Eeur_rEWBAksIg" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_BZHv4Do1Eeur_rEWBAksIg" type="7004">
+            <children xmi:type="notation:Node" xmi:id="_BZSH8Do1Eeur_rEWBAksIg" type="3010" element="_BYVFsDo1Eeur_rEWBAksIg">
+              <styles xmi:type="notation:FontStyle" xmi:id="_BZSH8To1Eeur_rEWBAksIg" fontColor="16777215" fontName="Segoe UI" fontHeight="8" bold="true"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_BZSH8jo1Eeur_rEWBAksIg"/>
             </children>
-            <styles xmi:type="notation:SortingStyle" xmi:id="_fIMjpZT8Eeqb8f7pGMdPvg"/>
-            <styles xmi:type="notation:FilteringStyle" xmi:id="_fIMjppT8Eeqb8f7pGMdPvg"/>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_BZHv4To1Eeur_rEWBAksIg"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_BZHv4jo1Eeur_rEWBAksIg"/>
           </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_fIMjoZT8Eeqb8f7pGMdPvg" fontName="Segoe UI" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIMjopT8Eeqb8f7pGMdPvg" x="280" y="330"/>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_BZGhwTo1Eeur_rEWBAksIg" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZGhwjo1Eeur_rEWBAksIg" x="365" y="315"/>
         </children>
-        <children xmi:type="notation:Node" xmi:id="_fIMjp5T8Eeqb8f7pGMdPvg" type="2003" element="_fHoi85T8Eeqb8f7pGMdPvg">
-          <children xmi:type="notation:Node" xmi:id="_fINKsJT8Eeqb8f7pGMdPvg" type="5007"/>
-          <children xmi:type="notation:Node" xmi:id="_fINKsZT8Eeqb8f7pGMdPvg" type="7004">
-            <styles xmi:type="notation:SortingStyle" xmi:id="_fINKspT8Eeqb8f7pGMdPvg"/>
-            <styles xmi:type="notation:FilteringStyle" xmi:id="_fINKs5T8Eeqb8f7pGMdPvg"/>
+        <children xmi:type="notation:Node" xmi:id="_BZI-ADo1Eeur_rEWBAksIg" type="2003" element="_BYTQgTo1Eeur_rEWBAksIg">
+          <children xmi:type="notation:Node" xmi:id="_BZKzMDo1Eeur_rEWBAksIg" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_BZKzMTo1Eeur_rEWBAksIg" type="7004">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_BZKzMjo1Eeur_rEWBAksIg"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_BZKzMzo1Eeur_rEWBAksIg"/>
           </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_fIMjqJT8Eeqb8f7pGMdPvg" fontName="Segoe UI" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIMjqZT8Eeqb8f7pGMdPvg" x="280" y="173"/>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_BZI-ATo1Eeur_rEWBAksIg" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZI-Ajo1Eeur_rEWBAksIg" x="365" y="171"/>
         </children>
-        <children xmi:type="notation:Node" xmi:id="_fINKtJT8Eeqb8f7pGMdPvg" type="2003" element="_fHoi9pT8Eeqb8f7pGMdPvg">
-          <children xmi:type="notation:Node" xmi:id="_fINKt5T8Eeqb8f7pGMdPvg" type="5007"/>
-          <children xmi:type="notation:Node" xmi:id="_fINxwJT8Eeqb8f7pGMdPvg" type="7004">
-            <styles xmi:type="notation:SortingStyle" xmi:id="_fINxwZT8Eeqb8f7pGMdPvg"/>
-            <styles xmi:type="notation:FilteringStyle" xmi:id="_fINxwpT8Eeqb8f7pGMdPvg"/>
+        <children xmi:type="notation:Node" xmi:id="_BZKzNDo1Eeur_rEWBAksIg" type="2003" element="_BYT3kjo1Eeur_rEWBAksIg">
+          <children xmi:type="notation:Node" xmi:id="_BZLaQDo1Eeur_rEWBAksIg" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_BZMBUDo1Eeur_rEWBAksIg" type="7004">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_BZMBUTo1Eeur_rEWBAksIg"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_BZMBUjo1Eeur_rEWBAksIg"/>
           </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_fINKtZT8Eeqb8f7pGMdPvg" fontName="Segoe UI" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fINKtpT8Eeqb8f7pGMdPvg" x="775" y="222"/>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_BZKzNTo1Eeur_rEWBAksIg" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZKzNjo1Eeur_rEWBAksIg" x="895" y="215"/>
         </children>
-        <children xmi:type="notation:Node" xmi:id="_fINxw5T8Eeqb8f7pGMdPvg" type="2003" element="_fHpKApT8Eeqb8f7pGMdPvg">
-          <children xmi:type="notation:Node" xmi:id="_fINxxpT8Eeqb8f7pGMdPvg" type="5007"/>
-          <children xmi:type="notation:Node" xmi:id="_fIQOAJT8Eeqb8f7pGMdPvg" type="7004">
-            <styles xmi:type="notation:SortingStyle" xmi:id="_fIQOAZT8Eeqb8f7pGMdPvg"/>
-            <styles xmi:type="notation:FilteringStyle" xmi:id="_fIQOApT8Eeqb8f7pGMdPvg"/>
+        <children xmi:type="notation:Node" xmi:id="_BZMBUzo1Eeur_rEWBAksIg" type="2003" element="_BYYwEDo1Eeur_rEWBAksIg">
+          <children xmi:type="notation:Node" xmi:id="_BZNPcDo1Eeur_rEWBAksIg" type="5007"/>
+          <children xmi:type="notation:Node" xmi:id="_BZNPcTo1Eeur_rEWBAksIg" type="7004">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_BZNPcjo1Eeur_rEWBAksIg"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_BZNPczo1Eeur_rEWBAksIg"/>
           </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_fINxxJT8Eeqb8f7pGMdPvg" fontColor="16777215" fontName="Segoe UI" fontHeight="8" bold="true"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fINxxZT8Eeqb8f7pGMdPvg" x="495" y="230"/>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_BZMBVDo1Eeur_rEWBAksIg" fontColor="16777215" fontName="Segoe UI" fontHeight="8" bold="true"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZMBVTo1Eeur_rEWBAksIg" x="530" y="219"/>
         </children>
         <styles xmi:type="notation:DiagramStyle" xmi:id="_fIKucpT8Eeqb8f7pGMdPvg"/>
-        <edges xmi:type="notation:Edge" xmi:id="_fIRcIJT8Eeqb8f7pGMdPvg" type="4001" element="_fHpxEJT8Eeqb8f7pGMdPvg" source="_fIL8kpT8Eeqb8f7pGMdPvg" target="_fINKtJT8Eeqb8f7pGMdPvg">
-          <children xmi:type="notation:Node" xmi:id="_fIRcJJT8Eeqb8f7pGMdPvg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIRcJZT8Eeqb8f7pGMdPvg" x="-4"/>
+        <edges xmi:type="notation:Edge" xmi:id="_BZgKYDo1Eeur_rEWBAksIg" type="4001" element="_BYe2sDo1Eeur_rEWBAksIg" source="_BZBpQDo1Eeur_rEWBAksIg" target="_BZKzNDo1Eeur_rEWBAksIg">
+          <children xmi:type="notation:Node" xmi:id="_BZgxcDo1Eeur_rEWBAksIg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZgxcTo1Eeur_rEWBAksIg" x="-4" y="-1"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_fIRcJpT8Eeqb8f7pGMdPvg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIRcJ5T8Eeqb8f7pGMdPvg" x="2" y="-3"/>
+          <children xmi:type="notation:Node" xmi:id="_BZhYgDo1Eeur_rEWBAksIg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZhYgTo1Eeur_rEWBAksIg" x="1" y="-3"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_fIRcKJT8Eeqb8f7pGMdPvg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIRcKZT8Eeqb8f7pGMdPvg" x="-1" y="-2"/>
+          <children xmi:type="notation:Node" xmi:id="_BZh_kDo1Eeur_rEWBAksIg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZh_kTo1Eeur_rEWBAksIg" x="3" y="-5"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_fIRcIZT8Eeqb8f7pGMdPvg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_fIRcIpT8Eeqb8f7pGMdPvg" fontName="Segoe UI" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fIRcI5T8Eeqb8f7pGMdPvg" points="[3, 4, -100, 1]$[99, 4, -4, 1]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fISDMJT8Eeqb8f7pGMdPvg" id="(0.9428571428571428,0.4406779661016949)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fISDMZT8Eeqb8f7pGMdPvg" id="(0.04081632653061224,0.5714285714285714)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_BZgKYTo1Eeur_rEWBAksIg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_BZgKYjo1Eeur_rEWBAksIg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BZgKYzo1Eeur_rEWBAksIg" points="[35, 0, -120, -2]$[155, 2, 0, 0]"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BZotQTo1Eeur_rEWBAksIg" id="(0.0,0.5306122448979592)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_fISDMpT8Eeqb8f7pGMdPvg" type="4001" element="_fHpxFZT8Eeqb8f7pGMdPvg" source="_fIKuc5T8Eeqb8f7pGMdPvg" target="_fIMjoJT8Eeqb8f7pGMdPvg">
-          <children xmi:type="notation:Node" xmi:id="_fISDNpT8Eeqb8f7pGMdPvg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fISDN5T8Eeqb8f7pGMdPvg" x="-12" y="-4"/>
+        <edges xmi:type="notation:Edge" xmi:id="_BZpUUDo1Eeur_rEWBAksIg" type="4001" element="_BYfdwjo1Eeur_rEWBAksIg" source="_BYs5IDo1Eeur_rEWBAksIg" target="_BZGhwDo1Eeur_rEWBAksIg">
+          <children xmi:type="notation:Node" xmi:id="_BZpUVDo1Eeur_rEWBAksIg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZpUVTo1Eeur_rEWBAksIg" x="-12" y="-3"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_fISqQJT8Eeqb8f7pGMdPvg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fISqQZT8Eeqb8f7pGMdPvg" x="11" y="3"/>
+          <children xmi:type="notation:Node" xmi:id="_BZpUVjo1Eeur_rEWBAksIg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZpUVzo1Eeur_rEWBAksIg" x="5"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_fISqQpT8Eeqb8f7pGMdPvg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fISqQ5T8Eeqb8f7pGMdPvg" x="13" y="1"/>
+          <children xmi:type="notation:Node" xmi:id="_BZpUWDo1Eeur_rEWBAksIg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZpUWTo1Eeur_rEWBAksIg" x="5" y="1"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_fISDM5T8Eeqb8f7pGMdPvg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_fISDNJT8Eeqb8f7pGMdPvg" fontName="Segoe UI" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fISDNZT8Eeqb8f7pGMdPvg" points="[8, 7, -106, 1]$[113, 7, -1, 1]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fISqRJT8Eeqb8f7pGMdPvg" id="(0.88,0.4782608695652174)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fISqRZT8Eeqb8f7pGMdPvg" id="(0.01020408163265306,0.5918367346938775)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_BZpUUTo1Eeur_rEWBAksIg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_BZpUUjo1Eeur_rEWBAksIg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BZpUUzo1Eeur_rEWBAksIg" points="[37, 5, -209, 0]$[244, 5, -2, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OohwcDo1Eeur_rEWBAksIg" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BZp7YTo1Eeur_rEWBAksIg" id="(0.02040816326530612,0.5918367346938775)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_fISqRpT8Eeqb8f7pGMdPvg" type="4001" element="_fHpxGpT8Eeqb8f7pGMdPvg" source="_fILVgpT8Eeqb8f7pGMdPvg" target="_fIMjp5T8Eeqb8f7pGMdPvg">
-          <children xmi:type="notation:Node" xmi:id="_fITRUJT8Eeqb8f7pGMdPvg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fITRUZT8Eeqb8f7pGMdPvg" x="-7" y="-3"/>
+        <edges xmi:type="notation:Edge" xmi:id="_BZp7Yjo1Eeur_rEWBAksIg" type="4001" element="_BYgE0jo1Eeur_rEWBAksIg" source="_BY_NADo1Eeur_rEWBAksIg" target="_BZI-ADo1Eeur_rEWBAksIg">
+          <children xmi:type="notation:Node" xmi:id="_BZp7Zjo1Eeur_rEWBAksIg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZp7Zzo1Eeur_rEWBAksIg" x="-11" y="-5"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_fITRUpT8Eeqb8f7pGMdPvg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fITRU5T8Eeqb8f7pGMdPvg" x="3" y="3"/>
+          <children xmi:type="notation:Node" xmi:id="_BZp7aDo1Eeur_rEWBAksIg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZp7aTo1Eeur_rEWBAksIg" x="13" y="2"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_fITRVJT8Eeqb8f7pGMdPvg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fITRVZT8Eeqb8f7pGMdPvg" x="7" y="2"/>
+          <children xmi:type="notation:Node" xmi:id="_BZqicDo1Eeur_rEWBAksIg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZqicTo1Eeur_rEWBAksIg" x="11" y="3"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_fISqR5T8Eeqb8f7pGMdPvg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_fISqSJT8Eeqb8f7pGMdPvg" fontName="Segoe UI" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fISqSZT8Eeqb8f7pGMdPvg" points="[5, 6, -115, 0]$[115, 6, -5, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fITRVpT8Eeqb8f7pGMdPvg" id="(0.9076923076923077,0.43283582089552236)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fITRV5T8Eeqb8f7pGMdPvg" id="(0.05102040816326531,0.5306122448979592)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_BZp7Yzo1Eeur_rEWBAksIg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_BZp7ZDo1Eeur_rEWBAksIg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BZp7ZTo1Eeur_rEWBAksIg" points="[4, -1, -221, 1]$[221, -1, -4, 1]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BZqicjo1Eeur_rEWBAksIg" id="(0.9230769230769231,0.4925373134328358)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BZqiczo1Eeur_rEWBAksIg" id="(0.04081632653061224,0.4489795918367347)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_fITRWJT8Eeqb8f7pGMdPvg" type="4001" element="_fHqYIpT8Eeqb8f7pGMdPvg" source="_fINxw5T8Eeqb8f7pGMdPvg" target="_fIL8kpT8Eeqb8f7pGMdPvg">
-          <children xmi:type="notation:Node" xmi:id="_fITRXJT8Eeqb8f7pGMdPvg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fITRXZT8Eeqb8f7pGMdPvg" x="-4" y="-1"/>
+        <edges xmi:type="notation:Edge" xmi:id="_BZrJgDo1Eeur_rEWBAksIg" type="4001" element="_BYh6ADo1Eeur_rEWBAksIg" source="_BZMBUzo1Eeur_rEWBAksIg" target="_BZBpQDo1Eeur_rEWBAksIg">
+          <children xmi:type="notation:Node" xmi:id="_BZrJhDo1Eeur_rEWBAksIg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZrJhTo1Eeur_rEWBAksIg" x="-4" y="-2"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_fIT4YJT8Eeqb8f7pGMdPvg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIT4YZT8Eeqb8f7pGMdPvg" x="-1" y="-1"/>
+          <children xmi:type="notation:Node" xmi:id="_BZrJhjo1Eeur_rEWBAksIg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZrJhzo1Eeur_rEWBAksIg" x="2" y="-4"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_fIT4YpT8Eeqb8f7pGMdPvg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIT4Y5T8Eeqb8f7pGMdPvg" x="-1" y="-1"/>
+          <children xmi:type="notation:Node" xmi:id="_BZrJiDo1Eeur_rEWBAksIg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZrJiTo1Eeur_rEWBAksIg" x="2" y="1"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_fITRWZT8Eeqb8f7pGMdPvg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_fITRWpT8Eeqb8f7pGMdPvg" fontName="Segoe UI" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fITRW5T8Eeqb8f7pGMdPvg" points="[1, 2, -56, 0]$[54, 2, -3, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fIT4ZJT8Eeqb8f7pGMdPvg" id="(0.9838709677419355,0.5365853658536586)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fIT4ZZT8Eeqb8f7pGMdPvg" id="(0.04285714285714286,0.559322033898305)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_BZrJgTo1Eeur_rEWBAksIg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_BZrJgjo1Eeur_rEWBAksIg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BZrJgzo1Eeur_rEWBAksIg" points="[1, 0, -119, -7]$[114, 6, -6, -1]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BZsXoDo1Eeur_rEWBAksIg" id="(0.9838709677419355,0.4146341463414634)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BZsXoTo1Eeur_rEWBAksIg" id="(0.08571428571428572,0.55)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_fIT4ZpT8Eeqb8f7pGMdPvg" type="4001" element="_fHqYJ5T8Eeqb8f7pGMdPvg" source="_fIMjoJT8Eeqb8f7pGMdPvg" target="_fINxw5T8Eeqb8f7pGMdPvg">
-          <children xmi:type="notation:Node" xmi:id="_fIT4apT8Eeqb8f7pGMdPvg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIT4a5T8Eeqb8f7pGMdPvg" x="-13" y="-11"/>
+        <edges xmi:type="notation:Edge" xmi:id="_BZsXojo1Eeur_rEWBAksIg" type="4001" element="_BYjIIDo1Eeur_rEWBAksIg" source="_BZGhwDo1Eeur_rEWBAksIg" target="_BZMBUzo1Eeur_rEWBAksIg">
+          <children xmi:type="notation:Node" xmi:id="_BZs-sDo1Eeur_rEWBAksIg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZs-sTo1Eeur_rEWBAksIg" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_fIT4bJT8Eeqb8f7pGMdPvg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIT4bZT8Eeqb8f7pGMdPvg" x="-5" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_BZs-sjo1Eeur_rEWBAksIg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZs-szo1Eeur_rEWBAksIg" x="-2" y="7"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_fIT4bpT8Eeqb8f7pGMdPvg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIT4b5T8Eeqb8f7pGMdPvg" x="-6"/>
+          <children xmi:type="notation:Node" xmi:id="_BZs-tDo1Eeur_rEWBAksIg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZs-tTo1Eeur_rEWBAksIg" x="-10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_fIT4Z5T8Eeqb8f7pGMdPvg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_fIT4aJT8Eeqb8f7pGMdPvg" fontName="Segoe UI" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fIT4aZT8Eeqb8f7pGMdPvg" points="[5, 0, -148, 83]$[153, 0, 0, 83]$[153, -83, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fIUfcJT8Eeqb8f7pGMdPvg" id="(0.9489795918367347,0.4897959183673469)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fIUfcZT8Eeqb8f7pGMdPvg" id="(0.5,1.0)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_BZsXozo1Eeur_rEWBAksIg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_BZsXpDo1Eeur_rEWBAksIg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BZsXpTo1Eeur_rEWBAksIg" points="[12, 4, -98, 80]$[104, 4, -6, 80]$[104, -76, -6, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BZtlwDo1Eeur_rEWBAksIg" id="(0.8775510204081632,0.42857142857142855)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BZtlwTo1Eeur_rEWBAksIg" id="(0.5,1.0)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_fIUfcpT8Eeqb8f7pGMdPvg" type="4001" element="_fHqYLJT8Eeqb8f7pGMdPvg" source="_fIMjp5T8Eeqb8f7pGMdPvg" target="_fINxw5T8Eeqb8f7pGMdPvg">
-          <children xmi:type="notation:Node" xmi:id="_fIUfdpT8Eeqb8f7pGMdPvg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIUfd5T8Eeqb8f7pGMdPvg" x="11" y="-9"/>
+        <edges xmi:type="notation:Edge" xmi:id="_BZtlwjo1Eeur_rEWBAksIg" type="4001" element="_BYjvMjo1Eeur_rEWBAksIg" source="_BZI-ADo1Eeur_rEWBAksIg" target="_BZMBUzo1Eeur_rEWBAksIg">
+          <children xmi:type="notation:Node" xmi:id="_BZuM0Do1Eeur_rEWBAksIg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZuM0To1Eeur_rEWBAksIg" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_fIUfeJT8Eeqb8f7pGMdPvg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIUfeZT8Eeqb8f7pGMdPvg" x="3" y="9"/>
+          <children xmi:type="notation:Node" xmi:id="_BZuM0jo1Eeur_rEWBAksIg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZuM0zo1Eeur_rEWBAksIg" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_fIUfepT8Eeqb8f7pGMdPvg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fIUfe5T8Eeqb8f7pGMdPvg" x="6"/>
+          <children xmi:type="notation:Node" xmi:id="_BZuM1Do1Eeur_rEWBAksIg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BZuM1To1Eeur_rEWBAksIg" x="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_fIUfc5T8Eeqb8f7pGMdPvg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_fIUfdJT8Eeqb8f7pGMdPvg" fontName="Segoe UI" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fIUfdZT8Eeqb8f7pGMdPvg" points="[5, 0, -148, -76]$[153, 0, 0, -76]$[153, 35, 0, -41]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fIUffJT8Eeqb8f7pGMdPvg" id="(0.9489795918367347,0.4489795918367347)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fIUffZT8Eeqb8f7pGMdPvg" id="(0.5,1.0)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_BZtlwzo1Eeur_rEWBAksIg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_BZtlxDo1Eeur_rEWBAksIg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BZtlxTo1Eeur_rEWBAksIg" points="[49, 9, -98, -80]$[141, 9, -6, -80]$[141, 48, -6, -41]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BZuz4Do1Eeur_rEWBAksIg" id="(0.5,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BZuz4To1Eeur_rEWBAksIg" id="(0.5,1.0)"/>
         </edges>
       </data>
     </ownedAnnotationEntries>
-    <ownedDiagramElements xmi:type="diagram:DNode" uid="_fHk4kJT8Eeqb8f7pGMdPvg" outgoingEdges="_fHpxFZT8Eeqb8f7pGMdPvg" width="-1" height="-1" resizeKind="NSEW">
-      <target xmi:type="pls:GenHandle" href="basic.pls#//@elements.0"/>
-      <semanticElements xmi:type="pls:GenHandle" href="basic.pls#//@elements.0"/>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_BW_B4Do1Eeur_rEWBAksIg" outgoingEdges="_BYfdwjo1Eeur_rEWBAksIg" width="-1" height="-1" resizeKind="NSEW">
+      <target xmi:type="pls:GenHandle" href="basic.pls#//@machines.0"/>
+      <semanticElements xmi:type="pls:GenHandle" href="basic.pls#//@machines.0"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_fHk4kZT8Eeqb8f7pGMdPvg" showIcon="false" workspacePath="/uk.ac.kcl.inf.modelling.pls.design/icons/GenHandle.png">
+      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_BXEhcDo1Eeur_rEWBAksIg" showIcon="false" workspacePath="/uk.ac.kcl.inf.modelling.pls.design/icons/GenHandle.png">
         <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@nodeMappings[name='GenHandle']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@nodeMappings[name='GenHandle']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNode" uid="_fHnU0ZT8Eeqb8f7pGMdPvg" outgoingEdges="_fHpxGpT8Eeqb8f7pGMdPvg" width="-1" height="-1" resizeKind="NSEW">
-      <target xmi:type="pls:GenHead" href="basic.pls#//@elements.1"/>
-      <semanticElements xmi:type="pls:GenHead" href="basic.pls#//@elements.1"/>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_BXGWoTo1Eeur_rEWBAksIg" outgoingEdges="_BYgE0jo1Eeur_rEWBAksIg" width="-1" height="-1" resizeKind="NSEW">
+      <target xmi:type="pls:GenHead" href="basic.pls#//@machines.1"/>
+      <semanticElements xmi:type="pls:GenHead" href="basic.pls#//@machines.1"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_fHn74JT8Eeqb8f7pGMdPvg" showIcon="false" workspacePath="/uk.ac.kcl.inf.modelling.pls.design/icons/GenHead.png">
+      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_BXG9sDo1Eeur_rEWBAksIg" showIcon="false" workspacePath="/uk.ac.kcl.inf.modelling.pls.design/icons/GenHead.png">
         <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@nodeMappings[name='GenHead']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@nodeMappings[name='GenHead']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNode" uid="_fHn74pT8Eeqb8f7pGMdPvg" outgoingEdges="_fHpxEJT8Eeqb8f7pGMdPvg" incomingEdges="_fHqYIpT8Eeqb8f7pGMdPvg" width="-1" height="-1" resizeKind="NSEW">
-      <target xmi:type="pls:Assembler" href="basic.pls#//@elements.2"/>
-      <semanticElements xmi:type="pls:Assembler" href="basic.pls#//@elements.2"/>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_BXG9sjo1Eeur_rEWBAksIg" outgoingEdges="_BYe2sDo1Eeur_rEWBAksIg" incomingEdges="_BYh6ADo1Eeur_rEWBAksIg" width="-1" height="-1" resizeKind="NSEW">
+      <target xmi:type="pls:Assembler" href="basic.pls#//@machines.2"/>
+      <semanticElements xmi:type="pls:Assembler" href="basic.pls#//@machines.2"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_fHn745T8Eeqb8f7pGMdPvg" showIcon="false" labelPosition="node" workspacePath="/uk.ac.kcl.inf.modelling.pls.design/icons/Assembler.png">
+      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_BXHkwDo1Eeur_rEWBAksIg" showIcon="false" labelPosition="node" workspacePath="/uk.ac.kcl.inf.modelling.pls.design/icons/Assembler.png">
         <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@nodeMappings[name='Assembler']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@nodeMappings[name='Assembler']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_fHoi8JT8Eeqb8f7pGMdPvg" name="1" outgoingEdges="_fHqYJ5T8Eeqb8f7pGMdPvg" incomingEdges="_fHpxFZT8Eeqb8f7pGMdPvg">
-      <target xmi:type="pls:Conveyor" href="basic.pls#//@elements.3"/>
-      <semanticElements xmi:type="pls:Conveyor" href="basic.pls#//@elements.3"/>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_BXIy4Do1Eeur_rEWBAksIg" name="1" outgoingEdges="_BYjIIDo1Eeur_rEWBAksIg" incomingEdges="_BYfdwjo1Eeur_rEWBAksIg">
+      <target xmi:type="pls:Conveyor" href="basic.pls#//@containers.0"/>
+      <semanticElements xmi:type="pls:Conveyor" href="basic.pls#//@containers.0"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_fHoi8ZT8Eeqb8f7pGMdPvg" showIcon="false" workspacePath="/uk.ac.kcl.inf.modelling.pls.design/icons/Conveyor.png">
+      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_BYSpcDo1Eeur_rEWBAksIg" showIcon="false" workspacePath="/uk.ac.kcl.inf.modelling.pls.design/icons/Conveyor.png">
         <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@containerMappings[name='ConveyorC']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@containerMappings[name='ConveyorC']"/>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_fHpKAJT8Eeqb8f7pGMdPvg" name="Handle">
-        <target xmi:type="pls:Handle" href="basic.pls#//@elements.4"/>
-        <semanticElements xmi:type="pls:Handle" href="basic.pls#//@elements.4"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_fHpKAZT8Eeqb8f7pGMdPvg" labelPosition="node">
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_BYVFsDo1Eeur_rEWBAksIg" name=":Handle">
+        <target xmi:type="pls:Handle" href="basic.pls#//@containers.0/@parts.0"/>
+        <semanticElements xmi:type="pls:Handle" href="basic.pls#//@containers.0/@parts.0"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_BYXh8Do1Eeur_rEWBAksIg" labelColor="255,255,255" borderSize="2" borderSizeComputationExpression="2" labelPosition="node" color="255,255,255">
+          <labelFormat>bold</labelFormat>
           <description xmi:type="style:BundledImageDescription" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@containerMappings[name='ConveyorC']/@subNodeMappings[name='PartNode']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@containerMappings[name='ConveyorC']/@subNodeMappings[name='PartNode']"/>
       </ownedElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_fHoi85T8Eeqb8f7pGMdPvg" name="0" outgoingEdges="_fHqYLJT8Eeqb8f7pGMdPvg" incomingEdges="_fHpxGpT8Eeqb8f7pGMdPvg">
-      <target xmi:type="pls:Conveyor" href="basic.pls#//@elements.5"/>
-      <semanticElements xmi:type="pls:Conveyor" href="basic.pls#//@elements.5"/>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_BYTQgTo1Eeur_rEWBAksIg" name="0" outgoingEdges="_BYjvMjo1Eeur_rEWBAksIg" incomingEdges="_BYgE0jo1Eeur_rEWBAksIg">
+      <target xmi:type="pls:Conveyor" href="basic.pls#//@containers.1"/>
+      <semanticElements xmi:type="pls:Conveyor" href="basic.pls#//@containers.1"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_fHoi9JT8Eeqb8f7pGMdPvg" showIcon="false" workspacePath="/uk.ac.kcl.inf.modelling.pls.design/icons/Conveyor.png">
+      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_BYT3kDo1Eeur_rEWBAksIg" showIcon="false" workspacePath="/uk.ac.kcl.inf.modelling.pls.design/icons/Conveyor.png">
         <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@containerMappings[name='ConveyorC']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@containerMappings[name='ConveyorC']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_fHoi9pT8Eeqb8f7pGMdPvg" name="0" incomingEdges="_fHpxEJT8Eeqb8f7pGMdPvg">
-      <target xmi:type="pls:Conveyor" href="basic.pls#//@elements.7"/>
-      <semanticElements xmi:type="pls:Conveyor" href="basic.pls#//@elements.7"/>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_BYT3kjo1Eeur_rEWBAksIg" name="0" incomingEdges="_BYe2sDo1Eeur_rEWBAksIg">
+      <target xmi:type="pls:Conveyor" href="basic.pls#//@containers.3"/>
+      <semanticElements xmi:type="pls:Conveyor" href="basic.pls#//@containers.3"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_fHoi95T8Eeqb8f7pGMdPvg" showIcon="false" workspacePath="/uk.ac.kcl.inf.modelling.pls.design/icons/Conveyor.png">
+      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_BYT3kzo1Eeur_rEWBAksIg" showIcon="false" workspacePath="/uk.ac.kcl.inf.modelling.pls.design/icons/Conveyor.png">
         <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@containerMappings[name='ConveyorC']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@containerMappings[name='ConveyorC']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_fHpKApT8Eeqb8f7pGMdPvg" name="0" outgoingEdges="_fHqYIpT8Eeqb8f7pGMdPvg" incomingEdges="_fHqYJ5T8Eeqb8f7pGMdPvg _fHqYLJT8Eeqb8f7pGMdPvg">
-      <target xmi:type="pls:Tray" href="basic.pls#//@elements.6"/>
-      <semanticElements xmi:type="pls:Tray" href="basic.pls#//@elements.6"/>
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_BYYwEDo1Eeur_rEWBAksIg" name="0" outgoingEdges="_BYh6ADo1Eeur_rEWBAksIg" incomingEdges="_BYjIIDo1Eeur_rEWBAksIg _BYjvMjo1Eeur_rEWBAksIg">
+      <target xmi:type="pls:Tray" href="basic.pls#//@containers.2"/>
+      <semanticElements xmi:type="pls:Tray" href="basic.pls#//@containers.2"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_fHpKA5T8Eeqb8f7pGMdPvg" showIcon="false" labelColor="255,255,255" workspacePath="/uk.ac.kcl.inf.modelling.pls.design/icons/Tray.png">
+      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_BYYwETo1Eeur_rEWBAksIg" showIcon="false" labelColor="255,255,255" workspacePath="/uk.ac.kcl.inf.modelling.pls.design/icons/Tray.png">
         <labelFormat>bold</labelFormat>
         <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@containerMappings[name='TrayC']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@containerMappings[name='TrayC']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_fHpxEJT8Eeqb8f7pGMdPvg" sourceNode="_fHn74pT8Eeqb8f7pGMdPvg" targetNode="_fHoi9pT8Eeqb8f7pGMdPvg">
-      <target xmi:type="pls:Assembler" href="basic.pls#//@elements.2"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_fHpxEZT8Eeqb8f7pGMdPvg" size="2">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BYe2sDo1Eeur_rEWBAksIg" sourceNode="_BXG9sjo1Eeur_rEWBAksIg" targetNode="_BYT3kjo1Eeur_rEWBAksIg">
+      <target xmi:type="pls:Assembler" href="basic.pls#//@machines.2"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BYe2sTo1Eeur_rEWBAksIg" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@edgeMappings[name='MachineOut']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_fHpxEpT8Eeqb8f7pGMdPvg"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BYe2sjo1Eeur_rEWBAksIg"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@edgeMappings[name='MachineOut']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_fHpxFZT8Eeqb8f7pGMdPvg" sourceNode="_fHk4kJT8Eeqb8f7pGMdPvg" targetNode="_fHoi8JT8Eeqb8f7pGMdPvg">
-      <target xmi:type="pls:GenHandle" href="basic.pls#//@elements.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_fHpxFpT8Eeqb8f7pGMdPvg" size="2">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BYfdwjo1Eeur_rEWBAksIg" sourceNode="_BW_B4Do1Eeur_rEWBAksIg" targetNode="_BXIy4Do1Eeur_rEWBAksIg">
+      <target xmi:type="pls:GenHandle" href="basic.pls#//@machines.0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BYfdwzo1Eeur_rEWBAksIg" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@edgeMappings[name='MachineOut']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_fHpxF5T8Eeqb8f7pGMdPvg"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BYfdxDo1Eeur_rEWBAksIg"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@edgeMappings[name='MachineOut']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_fHpxGpT8Eeqb8f7pGMdPvg" sourceNode="_fHnU0ZT8Eeqb8f7pGMdPvg" targetNode="_fHoi85T8Eeqb8f7pGMdPvg">
-      <target xmi:type="pls:GenHead" href="basic.pls#//@elements.1"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_fHpxG5T8Eeqb8f7pGMdPvg" size="2">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BYgE0jo1Eeur_rEWBAksIg" sourceNode="_BXGWoTo1Eeur_rEWBAksIg" targetNode="_BYTQgTo1Eeur_rEWBAksIg">
+      <target xmi:type="pls:GenHead" href="basic.pls#//@machines.1"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BYgE0zo1Eeur_rEWBAksIg" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@edgeMappings[name='MachineOut']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_fHpxHJT8Eeqb8f7pGMdPvg"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BYgE1Do1Eeur_rEWBAksIg"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@edgeMappings[name='MachineOut']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_fHqYIpT8Eeqb8f7pGMdPvg" sourceNode="_fHpKApT8Eeqb8f7pGMdPvg" targetNode="_fHn74pT8Eeqb8f7pGMdPvg">
-      <target xmi:type="pls:Tray" href="basic.pls#//@elements.6"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_fHqYI5T8Eeqb8f7pGMdPvg" size="2">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BYh6ADo1Eeur_rEWBAksIg" sourceNode="_BYYwEDo1Eeur_rEWBAksIg" targetNode="_BXG9sjo1Eeur_rEWBAksIg">
+      <target xmi:type="pls:Tray" href="basic.pls#//@containers.2"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BYh6ATo1Eeur_rEWBAksIg" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@edgeMappings[name='in']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_fHqYJJT8Eeqb8f7pGMdPvg"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BYh6Ajo1Eeur_rEWBAksIg"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@edgeMappings[name='in']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_fHqYJ5T8Eeqb8f7pGMdPvg" sourceNode="_fHoi8JT8Eeqb8f7pGMdPvg" targetNode="_fHpKApT8Eeqb8f7pGMdPvg">
-      <target xmi:type="pls:Conveyor" href="basic.pls#//@elements.3"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_fHqYKJT8Eeqb8f7pGMdPvg" size="2">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BYjIIDo1Eeur_rEWBAksIg" sourceNode="_BXIy4Do1Eeur_rEWBAksIg" targetNode="_BYYwEDo1Eeur_rEWBAksIg">
+      <target xmi:type="pls:Conveyor" href="basic.pls#//@containers.0"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BYjIITo1Eeur_rEWBAksIg" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@edgeMappings[name='transfer']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_fHqYKZT8Eeqb8f7pGMdPvg"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BYjIIjo1Eeur_rEWBAksIg"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@edgeMappings[name='transfer']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_fHqYLJT8Eeqb8f7pGMdPvg" sourceNode="_fHoi85T8Eeqb8f7pGMdPvg" targetNode="_fHpKApT8Eeqb8f7pGMdPvg">
-      <target xmi:type="pls:Conveyor" href="basic.pls#//@elements.5"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_fHq_MJT8Eeqb8f7pGMdPvg" size="2">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BYjvMjo1Eeur_rEWBAksIg" sourceNode="_BYTQgTo1Eeur_rEWBAksIg" targetNode="_BYYwEDo1Eeur_rEWBAksIg">
+      <target xmi:type="pls:Conveyor" href="basic.pls#//@containers.1"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BYkWQDo1Eeur_rEWBAksIg" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@edgeMappings[name='transfer']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_fHq_MZT8Eeqb8f7pGMdPvg"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BYkWQTo1Eeur_rEWBAksIg"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/uk.ac.kcl.inf.modelling.pls.design/description/pls.odesign#//@ownedViewpoints[name='Production%20Line%20Systems']/@ownedRepresentations[name='Production%20Line%20Diagram']/@defaultLayer/@edgeMappings[name='transfer']"/>
     </ownedDiagramElements>

--- a/uk.ac.kcl.inf.modelling.pls.henshin/src/pls.henshin
+++ b/uk.ac.kcl.inf.modelling.pls.henshin/src/pls.henshin
@@ -2,176 +2,169 @@
 <henshin:Module xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:henshin="http://www.eclipse.org/emf/2011/Henshin" xmi:id="_qTsvoHPFEeiMFLQF_CAn7Q" name="PLS">
   <imports href="https://inf.kcl.ac.uk/models/pls#/"/>
   <units xsi:type="henshin:Rule" xmi:id="_9uLLUHPFEei-YvDU9wix2w" name="generateHandle">
+    <annotations xmi:id="_VvLNkDo2Eeur_rEWBAksIg" key="featureModel" value=""/>
+    <annotations xmi:id="_VvLNkTo2Eeur_rEWBAksIg" key="injectiveMatchingPresenceCondition" value=""/>
+    <annotations xmi:id="_VvLNkjo2Eeur_rEWBAksIg" key="features" value=""/>
     <lhs xmi:id="_9upscHPFEei-YvDU9wix2w" name="Lhs">
-      <nodes xmi:id="__-V3IHPFEei-YvDU9wix2w" incoming="_HQyKAHPGEei-YvDU9wix2w" outgoing="_CWCHQHPGEei-YvDU9wix2w">
+      <nodes xmi:id="__-V3IHPFEei-YvDU9wix2w" outgoing="_CWCHQHPGEei-YvDU9wix2w">
         <annotations xmi:id="_Z7v38NKHEei6ycp1GjtRRQ" key="Target"/>
+        <annotations xmi:id="_VvEf4Do2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//GenHandle"/>
       </nodes>
       <nodes xmi:id="_AwZmMHPGEei-YvDU9wix2w" incoming="_CWCHQHPGEei-YvDU9wix2w">
+        <annotations xmi:id="_VvHjMDo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Conveyor"/>
       </nodes>
-      <nodes xmi:id="_F6dQQHPGEei-YvDU9wix2w" outgoing="_HQyKAHPGEei-YvDU9wix2w">
-        <type href="https://inf.kcl.ac.uk/models/pls#//ProductionLineModel"/>
-      </nodes>
       <edges xmi:id="_CWCHQHPGEei-YvDU9wix2w" source="__-V3IHPFEei-YvDU9wix2w" target="_AwZmMHPGEei-YvDU9wix2w">
+        <annotations xmi:id="_VvIxUDo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Machine/out"/>
-      </edges>
-      <edges xmi:id="_HQyKAHPGEei-YvDU9wix2w" source="_F6dQQHPGEei-YvDU9wix2w" target="__-V3IHPFEei-YvDU9wix2w">
-        <type href="https://inf.kcl.ac.uk/models/pls#//ProductionLineModel/elements"/>
       </edges>
     </lhs>
     <rhs xmi:id="_9upscXPFEei-YvDU9wix2w" name="Rhs">
-      <nodes xmi:id="__-V3IXPFEei-YvDU9wix2w" incoming="_HQyKAXPGEei-YvDU9wix2w" outgoing="_CWCHQXPGEei-YvDU9wix2w">
+      <nodes xmi:id="__-V3IXPFEei-YvDU9wix2w" outgoing="_CWCHQXPGEei-YvDU9wix2w">
+        <annotations xmi:id="_VvIxUTo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//GenHandle"/>
       </nodes>
       <nodes xmi:id="_AwZmMXPGEei-YvDU9wix2w" incoming="_CWCHQXPGEei-YvDU9wix2w" outgoing="_Cx_qgHPGEei-YvDU9wix2w">
+        <annotations xmi:id="_VvJYYDo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Conveyor"/>
       </nodes>
-      <nodes xmi:id="_Bx44YHPGEei-YvDU9wix2w" incoming="_Cx_qgHPGEei-YvDU9wix2w _Hf7ZQHPGEei-YvDU9wix2w">
+      <nodes xmi:id="_Bx44YHPGEei-YvDU9wix2w" incoming="_Cx_qgHPGEei-YvDU9wix2w">
+        <annotations xmi:id="_VvJYYTo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Handle"/>
       </nodes>
-      <nodes xmi:id="_GwvYAHPGEei-YvDU9wix2w" outgoing="_HQyKAXPGEei-YvDU9wix2w _Hf7ZQHPGEei-YvDU9wix2w">
-        <type href="https://inf.kcl.ac.uk/models/pls#//ProductionLineModel"/>
-      </nodes>
       <edges xmi:id="_CWCHQXPGEei-YvDU9wix2w" source="__-V3IXPFEei-YvDU9wix2w" target="_AwZmMXPGEei-YvDU9wix2w">
+        <annotations xmi:id="_VvJ_cTo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Machine/out"/>
       </edges>
       <edges xmi:id="_Cx_qgHPGEei-YvDU9wix2w" source="_AwZmMXPGEei-YvDU9wix2w" target="_Bx44YHPGEei-YvDU9wix2w">
+        <annotations xmi:id="_VvJ_cjo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Container/parts"/>
-      </edges>
-      <edges xmi:id="_HQyKAXPGEei-YvDU9wix2w" source="_GwvYAHPGEei-YvDU9wix2w" target="__-V3IXPFEei-YvDU9wix2w">
-        <type href="https://inf.kcl.ac.uk/models/pls#//ProductionLineModel/elements"/>
-      </edges>
-      <edges xmi:id="_Hf7ZQHPGEei-YvDU9wix2w" source="_GwvYAHPGEei-YvDU9wix2w" target="_Bx44YHPGEei-YvDU9wix2w">
-        <type href="https://inf.kcl.ac.uk/models/pls#//ProductionLineModel/elements"/>
       </edges>
     </rhs>
     <mappings xmi:id="__-V3InPFEei-YvDU9wix2w" origin="__-V3IHPFEei-YvDU9wix2w" image="__-V3IXPFEei-YvDU9wix2w"/>
     <mappings xmi:id="_AwZmMnPGEei-YvDU9wix2w" origin="_AwZmMHPGEei-YvDU9wix2w" image="_AwZmMXPGEei-YvDU9wix2w"/>
-    <mappings xmi:id="_GwvYAXPGEei-YvDU9wix2w" origin="_F6dQQHPGEei-YvDU9wix2w" image="_GwvYAHPGEei-YvDU9wix2w"/>
   </units>
   <units xsi:type="henshin:Rule" xmi:id="_T3LCwHPGEei-YvDU9wix2w" name="generateHead">
+    <annotations xmi:id="_XLWQozo2Eeur_rEWBAksIg" key="featureModel" value=""/>
+    <annotations xmi:id="_XLWQpDo2Eeur_rEWBAksIg" key="injectiveMatchingPresenceCondition" value=""/>
+    <annotations xmi:id="_XLXewDo2Eeur_rEWBAksIg" key="features" value=""/>
     <lhs xmi:id="_T3LCxXPGEei-YvDU9wix2w" name="Lhs">
-      <nodes xmi:id="_V7PzUHPGEei-YvDU9wix2w" incoming="_bN-RMHPGEei-YvDU9wix2w" outgoing="_agrGUHPGEei-YvDU9wix2w">
+      <nodes xmi:id="_V7PzUHPGEei-YvDU9wix2w" outgoing="_agrGUHPGEei-YvDU9wix2w">
         <annotations xmi:id="_cCErQNKHEei6ycp1GjtRRQ" key="Target"/>
+        <annotations xmi:id="_XLVCgDo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//GenHead"/>
       </nodes>
-      <nodes xmi:id="_WWWa8HPGEei-YvDU9wix2w" outgoing="_bN-RMHPGEei-YvDU9wix2w">
-        <type href="https://inf.kcl.ac.uk/models/pls#//ProductionLineModel"/>
-      </nodes>
       <nodes xmi:id="_YUe7kHPGEei-YvDU9wix2w" incoming="_agrGUHPGEei-YvDU9wix2w">
+        <annotations xmi:id="_XLVpkTo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Conveyor"/>
       </nodes>
       <edges xmi:id="_agrGUHPGEei-YvDU9wix2w" source="_V7PzUHPGEei-YvDU9wix2w" target="_YUe7kHPGEei-YvDU9wix2w">
+        <annotations xmi:id="_XLVpkjo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Machine/out"/>
-      </edges>
-      <edges xmi:id="_bN-RMHPGEei-YvDU9wix2w" source="_WWWa8HPGEei-YvDU9wix2w" target="_V7PzUHPGEei-YvDU9wix2w">
-        <type href="https://inf.kcl.ac.uk/models/pls#//ProductionLineModel/elements"/>
       </edges>
     </lhs>
     <rhs xmi:id="_T3LCxnPGEei-YvDU9wix2w" name="Rhs">
-      <nodes xmi:id="_V7PzUXPGEei-YvDU9wix2w" incoming="_bN-RMXPGEei-YvDU9wix2w" outgoing="_agrGUXPGEei-YvDU9wix2w">
+      <nodes xmi:id="_V7PzUXPGEei-YvDU9wix2w" outgoing="_agrGUXPGEei-YvDU9wix2w">
+        <annotations xmi:id="_XLVpkzo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//GenHead"/>
       </nodes>
-      <nodes xmi:id="_WWWa8XPGEei-YvDU9wix2w" outgoing="_bAnxsHPGEei-YvDU9wix2w _bN-RMXPGEei-YvDU9wix2w">
-        <type href="https://inf.kcl.ac.uk/models/pls#//ProductionLineModel"/>
-      </nodes>
       <nodes xmi:id="_YUe7kXPGEei-YvDU9wix2w" incoming="_agrGUXPGEei-YvDU9wix2w" outgoing="_awkjgHPGEei-YvDU9wix2w">
+        <annotations xmi:id="_XLVplTo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Conveyor"/>
       </nodes>
-      <nodes xmi:id="_ZBt1AHPGEei-YvDU9wix2w" incoming="_awkjgHPGEei-YvDU9wix2w _bAnxsHPGEei-YvDU9wix2w">
+      <nodes xmi:id="_ZBt1AHPGEei-YvDU9wix2w" incoming="_awkjgHPGEei-YvDU9wix2w">
+        <annotations xmi:id="_XLWQoDo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Head"/>
       </nodes>
       <edges xmi:id="_agrGUXPGEei-YvDU9wix2w" source="_V7PzUXPGEei-YvDU9wix2w" target="_YUe7kXPGEei-YvDU9wix2w">
+        <annotations xmi:id="_XLWQoTo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Machine/out"/>
       </edges>
       <edges xmi:id="_awkjgHPGEei-YvDU9wix2w" source="_YUe7kXPGEei-YvDU9wix2w" target="_ZBt1AHPGEei-YvDU9wix2w">
+        <annotations xmi:id="_XLWQojo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Container/parts"/>
-      </edges>
-      <edges xmi:id="_bAnxsHPGEei-YvDU9wix2w" source="_WWWa8XPGEei-YvDU9wix2w" target="_ZBt1AHPGEei-YvDU9wix2w">
-        <type href="https://inf.kcl.ac.uk/models/pls#//ProductionLineModel/elements"/>
-      </edges>
-      <edges xmi:id="_bN-RMXPGEei-YvDU9wix2w" source="_WWWa8XPGEei-YvDU9wix2w" target="_V7PzUXPGEei-YvDU9wix2w">
-        <type href="https://inf.kcl.ac.uk/models/pls#//ProductionLineModel/elements"/>
       </edges>
     </rhs>
     <mappings xmi:id="_V7PzUnPGEei-YvDU9wix2w" origin="_V7PzUHPGEei-YvDU9wix2w" image="_V7PzUXPGEei-YvDU9wix2w"/>
-    <mappings xmi:id="_WWWa8nPGEei-YvDU9wix2w" origin="_WWWa8HPGEei-YvDU9wix2w" image="_WWWa8XPGEei-YvDU9wix2w"/>
     <mappings xmi:id="_YUe7knPGEei-YvDU9wix2w" origin="_YUe7kHPGEei-YvDU9wix2w" image="_YUe7kXPGEei-YvDU9wix2w"/>
   </units>
   <units xsi:type="henshin:Rule" xmi:id="_nZ_iIHPGEei-YvDU9wix2w" name="assemble">
+    <annotations xmi:id="_YK8scDo2Eeur_rEWBAksIg" key="featureModel" value=""/>
+    <annotations xmi:id="_YK8scTo2Eeur_rEWBAksIg" key="injectiveMatchingPresenceCondition" value=""/>
+    <annotations xmi:id="_YK8scjo2Eeur_rEWBAksIg" key="features" value=""/>
     <lhs xmi:id="_nZ_iJXPGEei-YvDU9wix2w" name="Lhs">
       <nodes xmi:id="_pCz6EHPGEei-YvDU9wix2w" outgoing="_v3GRUHPGEei-YvDU9wix2w _wFFC8HPGEei-YvDU9wix2w">
         <annotations xmi:id="_egkG8NKHEei6ycp1GjtRRQ" key="Target"/>
+        <annotations xmi:id="_YK63QDo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Assembler"/>
       </nodes>
       <nodes xmi:id="_qM02IHPGEei-YvDU9wix2w" incoming="_v3GRUHPGEei-YvDU9wix2w" outgoing="_vOwe8HPGEei-YvDU9wix2w _vdhTsHPGEei-YvDU9wix2w">
+        <annotations xmi:id="_YK63QTo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Tray"/>
       </nodes>
       <nodes xmi:id="_q0eE8HPGEei-YvDU9wix2w" incoming="_wFFC8HPGEei-YvDU9wix2w">
+        <annotations xmi:id="_YK63Qjo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Conveyor"/>
       </nodes>
-      <nodes xmi:id="_rdUNoHPGEei-YvDU9wix2w" incoming="_vOwe8HPGEei-YvDU9wix2w _RrY08IUPEei0FfH_M_cW1g">
+      <nodes xmi:id="_rdUNoHPGEei-YvDU9wix2w" incoming="_vOwe8HPGEei-YvDU9wix2w">
+        <annotations xmi:id="_YK7eUDo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Handle"/>
       </nodes>
-      <nodes xmi:id="_ryJOIHPGEei-YvDU9wix2w" incoming="_vdhTsHPGEei-YvDU9wix2w _lCqWMIUQEeix5NK6BRBUTA">
+      <nodes xmi:id="_ryJOIHPGEei-YvDU9wix2w" incoming="_vdhTsHPGEei-YvDU9wix2w">
+        <annotations xmi:id="_YK7eUTo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Head"/>
       </nodes>
-      <nodes xmi:id="_QCLbcIUPEei0FfH_M_cW1g" outgoing="_RrY08IUPEei0FfH_M_cW1g _lCqWMIUQEeix5NK6BRBUTA">
-        <type href="https://inf.kcl.ac.uk/models/pls#//ProductionLineModel"/>
-      </nodes>
       <edges xmi:id="_vOwe8HPGEei-YvDU9wix2w" source="_qM02IHPGEei-YvDU9wix2w" target="_rdUNoHPGEei-YvDU9wix2w">
+        <annotations xmi:id="_YK7eUzo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Container/parts"/>
       </edges>
       <edges xmi:id="_vdhTsHPGEei-YvDU9wix2w" source="_qM02IHPGEei-YvDU9wix2w" target="_ryJOIHPGEei-YvDU9wix2w">
+        <annotations xmi:id="_YK7eVDo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Container/parts"/>
       </edges>
       <edges xmi:id="_v3GRUHPGEei-YvDU9wix2w" source="_pCz6EHPGEei-YvDU9wix2w" target="_qM02IHPGEei-YvDU9wix2w">
+        <annotations xmi:id="_YK7eVTo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Machine/in"/>
       </edges>
       <edges xmi:id="_wFFC8HPGEei-YvDU9wix2w" source="_pCz6EHPGEei-YvDU9wix2w" target="_q0eE8HPGEei-YvDU9wix2w">
+        <annotations xmi:id="_YK8FYDo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Machine/out"/>
-      </edges>
-      <edges xmi:id="_RrY08IUPEei0FfH_M_cW1g" source="_QCLbcIUPEei0FfH_M_cW1g" target="_rdUNoHPGEei-YvDU9wix2w">
-        <type href="https://inf.kcl.ac.uk/models/pls#//ProductionLineModel/elements"/>
-      </edges>
-      <edges xmi:id="_lCqWMIUQEeix5NK6BRBUTA" source="_QCLbcIUPEei0FfH_M_cW1g" target="_ryJOIHPGEei-YvDU9wix2w">
-        <type href="https://inf.kcl.ac.uk/models/pls#//ProductionLineModel/elements"/>
       </edges>
     </lhs>
     <rhs xmi:id="_nZ_iJnPGEei-YvDU9wix2w" name="Rhs">
       <nodes xmi:id="_pCz6EXPGEei-YvDU9wix2w" outgoing="_v3GRUXPGEei-YvDU9wix2w _wFFC8XPGEei-YvDU9wix2w">
+        <annotations xmi:id="_YK8FYTo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Assembler"/>
       </nodes>
       <nodes xmi:id="_qM02IXPGEei-YvDU9wix2w" incoming="_v3GRUXPGEei-YvDU9wix2w">
+        <annotations xmi:id="_YK8FYjo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Tray"/>
       </nodes>
       <nodes xmi:id="_q0eE8XPGEei-YvDU9wix2w" incoming="_wFFC8XPGEei-YvDU9wix2w" outgoing="_vpJU4HPGEei-YvDU9wix2w">
+        <annotations xmi:id="_YK8FYzo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Conveyor"/>
       </nodes>
-      <nodes xmi:id="_sOvqkHPGEei-YvDU9wix2w" incoming="_vpJU4HPGEei-YvDU9wix2w _R-ohEIUPEei0FfH_M_cW1g">
+      <nodes xmi:id="_sOvqkHPGEei-YvDU9wix2w" incoming="_vpJU4HPGEei-YvDU9wix2w">
+        <annotations xmi:id="_YK8FZDo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Hammer"/>
       </nodes>
-      <nodes xmi:id="_RFaaEIUPEei0FfH_M_cW1g" outgoing="_R-ohEIUPEei0FfH_M_cW1g">
-        <type href="https://inf.kcl.ac.uk/models/pls#//ProductionLineModel"/>
-      </nodes>
       <edges xmi:id="_vpJU4HPGEei-YvDU9wix2w" source="_q0eE8XPGEei-YvDU9wix2w" target="_sOvqkHPGEei-YvDU9wix2w">
+        <annotations xmi:id="_YK8FZjo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Container/parts"/>
       </edges>
       <edges xmi:id="_v3GRUXPGEei-YvDU9wix2w" source="_pCz6EXPGEei-YvDU9wix2w" target="_qM02IXPGEei-YvDU9wix2w">
+        <annotations xmi:id="_YK8FZzo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Machine/in"/>
       </edges>
       <edges xmi:id="_wFFC8XPGEei-YvDU9wix2w" source="_pCz6EXPGEei-YvDU9wix2w" target="_q0eE8XPGEei-YvDU9wix2w">
+        <annotations xmi:id="_YK8FaDo2Eeur_rEWBAksIg" key="presenceCondition" value=""/>
         <type href="https://inf.kcl.ac.uk/models/pls#//Machine/out"/>
-      </edges>
-      <edges xmi:id="_R-ohEIUPEei0FfH_M_cW1g" source="_RFaaEIUPEei0FfH_M_cW1g" target="_sOvqkHPGEei-YvDU9wix2w">
-        <type href="https://inf.kcl.ac.uk/models/pls#//ProductionLineModel/elements"/>
       </edges>
     </rhs>
     <mappings xmi:id="_pCz6EnPGEei-YvDU9wix2w" origin="_pCz6EHPGEei-YvDU9wix2w" image="_pCz6EXPGEei-YvDU9wix2w"/>
     <mappings xmi:id="_qM02InPGEei-YvDU9wix2w" origin="_qM02IHPGEei-YvDU9wix2w" image="_qM02IXPGEei-YvDU9wix2w"/>
     <mappings xmi:id="_q0eE8nPGEei-YvDU9wix2w" origin="_q0eE8HPGEei-YvDU9wix2w" image="_q0eE8XPGEei-YvDU9wix2w"/>
-    <mappings xmi:id="_RFaaEYUPEei0FfH_M_cW1g" origin="_QCLbcIUPEei0FfH_M_cW1g" image="_RFaaEIUPEei0FfH_M_cW1g"/>
   </units>
   <units xsi:type="henshin:Rule" xmi:id="_6FWOAHPGEei-YvDU9wix2w" name="moveAlong">
     <lhs xmi:id="_6FWOBXPGEei-YvDU9wix2w" name="Lhs">

--- a/uk.ac.kcl.inf.modelling.pls.henshin/src/pls.henshin_diagram
+++ b/uk.ac.kcl.inf.modelling.pls.henshin/src/pls.henshin_diagram
@@ -36,16 +36,6 @@
         <element xmi:type="henshin:Node" href="pls.henshin#_Bx44YHPGEei-YvDU9wix2w"/>
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bx44ZHPGEei-YvDU9wix2w" x="184" y="68"/>
       </children>
-      <children xmi:type="notation:Shape" xmi:id="_F6dQQ3PGEei-YvDU9wix2w" type="3001" fontName="Segoe UI">
-        <children xmi:type="notation:DecorationNode" xmi:id="_F6dQRXPGEei-YvDU9wix2w" type="5002"/>
-        <children xmi:type="notation:DecorationNode" xmi:id="_F6dQRnPGEei-YvDU9wix2w" type="5003"/>
-        <children xmi:type="notation:DecorationNode" xmi:id="_F6dQR3PGEei-YvDU9wix2w" type="7002">
-          <styles xmi:type="notation:SortingStyle" xmi:id="_F6dQSHPGEei-YvDU9wix2w"/>
-          <styles xmi:type="notation:FilteringStyle" xmi:id="_F6dQSXPGEei-YvDU9wix2w"/>
-        </children>
-        <element xmi:type="henshin:Node" href="pls.henshin#_F6dQQHPGEei-YvDU9wix2w"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F6dQRHPGEei-YvDU9wix2w" x="2" y="68"/>
-      </children>
     </children>
     <element xmi:type="henshin:Rule" href="pls.henshin#_9uLLUHPFEei-YvDU9wix2w"/>
     <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9uVjYXPFEei-YvDU9wix2w" x="312" y="24" width="252" height="148"/>
@@ -65,16 +55,6 @@
         </children>
         <element xmi:type="henshin:Node" href="pls.henshin#_V7PzUHPGEei-YvDU9wix2w"/>
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_V7PzVnPGEei-YvDU9wix2w" x="33" y="1"/>
-      </children>
-      <children xmi:type="notation:Shape" xmi:id="_WWWa83PGEei-YvDU9wix2w" type="3001" fontName="Segoe UI">
-        <children xmi:type="notation:DecorationNode" xmi:id="_WWWa9XPGEei-YvDU9wix2w" type="5002"/>
-        <children xmi:type="notation:DecorationNode" xmi:id="_WWWa9nPGEei-YvDU9wix2w" type="5003"/>
-        <children xmi:type="notation:DecorationNode" xmi:id="_WWfk4HPGEei-YvDU9wix2w" type="7002">
-          <styles xmi:type="notation:SortingStyle" xmi:id="_WWfk4XPGEei-YvDU9wix2w"/>
-          <styles xmi:type="notation:FilteringStyle" xmi:id="_WWfk4nPGEei-YvDU9wix2w"/>
-        </children>
-        <element xmi:type="henshin:Node" href="pls.henshin#_WWWa8HPGEei-YvDU9wix2w"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WWWa9HPGEei-YvDU9wix2w" x="3" y="70"/>
       </children>
       <children xmi:type="notation:Shape" xmi:id="_YUe7k3PGEei-YvDU9wix2w" type="3001" fontName="Segoe UI">
         <children xmi:type="notation:DecorationNode" xmi:id="_YUe7lXPGEei-YvDU9wix2w" type="5002"/>
@@ -114,7 +94,7 @@
           <styles xmi:type="notation:FilteringStyle" xmi:id="_pC9rFnPGEei-YvDU9wix2w"/>
         </children>
         <element xmi:type="henshin:Node" href="pls.henshin#_pCz6EHPGEei-YvDU9wix2w"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pC9rEXPGEei-YvDU9wix2w" x="125" y="131"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pC9rEXPGEei-YvDU9wix2w" x="116" y="73"/>
       </children>
       <children xmi:type="notation:Shape" xmi:id="_qM02I3PGEei-YvDU9wix2w" type="3001" fontName="Segoe UI">
         <children xmi:type="notation:DecorationNode" xmi:id="_qM02JXPGEei-YvDU9wix2w" type="5002"/>
@@ -124,7 +104,7 @@
           <styles xmi:type="notation:FilteringStyle" xmi:id="_qM02KXPGEei-YvDU9wix2w"/>
         </children>
         <element xmi:type="henshin:Node" href="pls.henshin#_qM02IHPGEei-YvDU9wix2w"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qM02JHPGEei-YvDU9wix2w" x="12" y="131"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qM02JHPGEei-YvDU9wix2w" x="3" y="73"/>
       </children>
       <children xmi:type="notation:Shape" xmi:id="_q0eE83PGEei-YvDU9wix2w" type="3001" fontName="Segoe UI">
         <children xmi:type="notation:DecorationNode" xmi:id="_q0eE9XPGEei-YvDU9wix2w" type="5002"/>
@@ -134,7 +114,7 @@
           <styles xmi:type="notation:FilteringStyle" xmi:id="_q0eE-XPGEei-YvDU9wix2w"/>
         </children>
         <element xmi:type="henshin:Node" href="pls.henshin#_q0eE8HPGEei-YvDU9wix2w"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q0eE9HPGEei-YvDU9wix2w" x="148" y="73"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q0eE9HPGEei-YvDU9wix2w" x="218" y="73"/>
       </children>
       <children xmi:type="notation:Shape" xmi:id="_rdUNo3PGEei-YvDU9wix2w" type="3001" fontName="Segoe UI">
         <children xmi:type="notation:DecorationNode" xmi:id="_rdUNpXPGEei-YvDU9wix2w" type="5002"/>
@@ -154,7 +134,7 @@
           <styles xmi:type="notation:FilteringStyle" xmi:id="_ryJOKXPGEei-YvDU9wix2w"/>
         </children>
         <element xmi:type="henshin:Node" href="pls.henshin#_ryJOIHPGEei-YvDU9wix2w"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ryJOJHPGEei-YvDU9wix2w" x="38" y="50"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ryJOJHPGEei-YvDU9wix2w" x="58" y="3"/>
       </children>
       <children xmi:type="notation:Shape" xmi:id="_sO5bkHPGEei-YvDU9wix2w" type="3001" fontName="Segoe UI">
         <children xmi:type="notation:DecorationNode" xmi:id="_sO5bknPGEei-YvDU9wix2w" type="5002"/>
@@ -164,21 +144,11 @@
           <styles xmi:type="notation:FilteringStyle" xmi:id="_sO5blnPGEei-YvDU9wix2w"/>
         </children>
         <element xmi:type="henshin:Node" href="pls.henshin#_sOvqkHPGEei-YvDU9wix2w"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sO5bkXPGEei-YvDU9wix2w" x="219" y="131"/>
-      </children>
-      <children xmi:type="notation:Shape" xmi:id="_QCVzgIUPEei0FfH_M_cW1g" type="3001" fontName="Segoe UI">
-        <children xmi:type="notation:DecorationNode" xmi:id="_QCVzgoUPEei0FfH_M_cW1g" type="5002"/>
-        <children xmi:type="notation:DecorationNode" xmi:id="_QCVzg4UPEei0FfH_M_cW1g" type="5003"/>
-        <children xmi:type="notation:DecorationNode" xmi:id="_QCVzhIUPEei0FfH_M_cW1g" type="7002">
-          <styles xmi:type="notation:SortingStyle" xmi:id="_QCVzhYUPEei0FfH_M_cW1g"/>
-          <styles xmi:type="notation:FilteringStyle" xmi:id="_QCVzhoUPEei0FfH_M_cW1g"/>
-        </children>
-        <element xmi:type="henshin:Node" href="pls.henshin#_QCLbcIUPEei0FfH_M_cW1g"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QCVzgYUPEei0FfH_M_cW1g" x="164" y="3"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sO5bkXPGEei-YvDU9wix2w" x="219" y="3"/>
       </children>
     </children>
     <element xmi:type="henshin:Rule" href="pls.henshin#_nZ_iIHPGEei-YvDU9wix2w"/>
-    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nZ_iInPGEei-YvDU9wix2w" x="312" y="179" width="298" height="210"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nZ_iInPGEei-YvDU9wix2w" x="312" y="179" width="298" height="158"/>
   </children>
   <children xmi:type="notation:Shape" xmi:id="_6FWOAXPGEei-YvDU9wix2w" type="2001" fontName="Segoe UI" italic="true" lineColor="0">
     <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_7X1wo3PGEei-YvDU9wix2w" source="defaultAction">
@@ -244,31 +214,6 @@
     <element xmi:type="henshin:Edge" href="pls.henshin#_Cx_qgHPGEei-YvDU9wix2w"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Cx_qhHPGEei-YvDU9wix2w" points="[-9, 21, -12, -61]$[-27, 84, -30, 2]"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_HQyKAnPGEei-YvDU9wix2w" type="4001" source="_F6dQQ3PGEei-YvDU9wix2w" target="__-V3JXPFEei-YvDU9wix2w">
-    <children xmi:type="notation:DecorationNode" xmi:id="_HQyKBXPGEei-YvDU9wix2w" type="6001">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_HQyKBnPGEei-YvDU9wix2w" x="7" y="29"/>
-    </children>
-    <children xmi:type="notation:DecorationNode" xmi:id="_HQyKB3PGEei-YvDU9wix2w" type="6002">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_HQyKCHPGEei-YvDU9wix2w" x="7" y="-33"/>
-    </children>
-    <styles xmi:type="notation:FontStyle" xmi:id="_HQyKA3PGEei-YvDU9wix2w" fontName="Segoe UI"/>
-    <element xmi:type="henshin:Edge" href="pls.henshin#_HQyKAHPGEei-YvDU9wix2w"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HQyKBHPGEei-YvDU9wix2w" points="[-4, -7, 27, 63]$[-15, -27, 16, 43]$[-23, -49, 8, 21]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HQyKCXPGEei-YvDU9wix2w" id="(0.5,0.07142857142857142)"/>
-  </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_Hf7ZQXPGEei-YvDU9wix2w" type="4001" source="_F6dQQ3PGEei-YvDU9wix2w" target="_Bx44Y3PGEei-YvDU9wix2w">
-    <children xmi:type="notation:DecorationNode" xmi:id="_Hf7ZRHPGEei-YvDU9wix2w" type="6001">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_Hf7ZRXPGEei-YvDU9wix2w" x="-4" y="10"/>
-    </children>
-    <children xmi:type="notation:DecorationNode" xmi:id="_Hf7ZRnPGEei-YvDU9wix2w" type="6002">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_Hf7ZR3PGEei-YvDU9wix2w" x="3" y="-11"/>
-    </children>
-    <styles xmi:type="notation:FontStyle" xmi:id="_Hf7ZQnPGEei-YvDU9wix2w" fontName="Segoe UI"/>
-    <element xmi:type="henshin:Edge" href="pls.henshin#_Hf7ZQHPGEei-YvDU9wix2w"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Hf7ZQ3PGEei-YvDU9wix2w" points="[27, -3, -83, 9]$[99, -15, -11, -3]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hf7ZSHPGEei-YvDU9wix2w" id="(0.7786885245901639,0.5)"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hf7ZSXPGEei-YvDU9wix2w" id="(0.22448979591836735,0.42857142857142855)"/>
-  </edges>
   <edges xmi:type="notation:Connector" xmi:id="_agrGUnPGEei-YvDU9wix2w" type="4001" source="_V7PzVXPGEei-YvDU9wix2w" target="_YUe7k3PGEei-YvDU9wix2w">
     <children xmi:type="notation:DecorationNode" xmi:id="_agrGVXPGEei-YvDU9wix2w" type="6001">
       <layoutConstraint xmi:type="notation:Location" xmi:id="_agrGVnPGEei-YvDU9wix2w" y="10"/>
@@ -294,37 +239,12 @@
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_awkjg3PGEei-YvDU9wix2w" points="[3, 21, 0, -58]$[4, 75, 1, -4]"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_awu7kHPGEei-YvDU9wix2w" id="(0.6122448979591837,0.09523809523809523)"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_bAnxsXPGEei-YvDU9wix2w" type="4001" source="_WWWa83PGEei-YvDU9wix2w" target="_ZBt1A3PGEei-YvDU9wix2w">
-    <children xmi:type="notation:DecorationNode" xmi:id="_bAnxtHPGEei-YvDU9wix2w" type="6001">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_bAnxtXPGEei-YvDU9wix2w" x="-4" y="10"/>
-    </children>
-    <children xmi:type="notation:DecorationNode" xmi:id="_bAnxtnPGEei-YvDU9wix2w" type="6002">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_bAnxt3PGEei-YvDU9wix2w" y="-11"/>
-    </children>
-    <styles xmi:type="notation:FontStyle" xmi:id="_bAnxsnPGEei-YvDU9wix2w" fontName="Segoe UI"/>
-    <element xmi:type="henshin:Edge" href="pls.henshin#_bAnxsHPGEei-YvDU9wix2w"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bAnxs3PGEei-YvDU9wix2w" points="[61, -4, -87, 0]$[137, -11, -11, -7]"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bAnxuHPGEei-YvDU9wix2w" id="(0.22448979591836735,0.30952380952380953)"/>
-  </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_bN-RMnPGEei-YvDU9wix2w" type="4001" source="_WWWa83PGEei-YvDU9wix2w" target="_V7PzVXPGEei-YvDU9wix2w">
-    <children xmi:type="notation:DecorationNode" xmi:id="_bN-RNXPGEei-YvDU9wix2w" type="6001">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_bN-RNnPGEei-YvDU9wix2w" x="-1" y="29"/>
-    </children>
-    <children xmi:type="notation:DecorationNode" xmi:id="_bN-RN3PGEei-YvDU9wix2w" type="6002">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_bN-ROHPGEei-YvDU9wix2w" x="1" y="-32"/>
-    </children>
-    <styles xmi:type="notation:FontStyle" xmi:id="_bN-RM3PGEei-YvDU9wix2w" fontName="Segoe UI"/>
-    <element xmi:type="henshin:Edge" href="pls.henshin#_bN-RMHPGEei-YvDU9wix2w"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bN-RNHPGEei-YvDU9wix2w" points="[-11, -21, 37, 73]$[-58, -92, -10, 2]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c8bXEHPGEei-YvDU9wix2w" id="(0.4918032786885246,0.14285714285714285)"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bOICMHPGEei-YvDU9wix2w" id="(0.4918032786885246,0.8571428571428571)"/>
-  </edges>
   <edges xmi:type="notation:Connector" xmi:id="_vOwe8XPGEei-YvDU9wix2w" type="4001" source="_qM02I3PGEei-YvDU9wix2w" target="_rdUNo3PGEei-YvDU9wix2w">
     <children xmi:type="notation:DecorationNode" xmi:id="_vOwe9HPGEei-YvDU9wix2w" type="6001">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_vOwe9XPGEei-YvDU9wix2w" x="-33" y="17"/>
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_vOwe9XPGEei-YvDU9wix2w" x="-7" y="23"/>
     </children>
     <children xmi:type="notation:DecorationNode" xmi:id="_vOwe9nPGEei-YvDU9wix2w" type="6002">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_vOwe93PGEei-YvDU9wix2w" x="-19" y="27"/>
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_vOwe93PGEei-YvDU9wix2w" x="8" y="26"/>
     </children>
     <styles xmi:type="notation:FontStyle" xmi:id="_vOwe8nPGEei-YvDU9wix2w" fontName="Segoe UI"/>
     <element xmi:type="henshin:Edge" href="pls.henshin#_vOwe8HPGEei-YvDU9wix2w"/>
@@ -334,10 +254,10 @@
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_vdhTsXPGEei-YvDU9wix2w" type="4001" source="_qM02I3PGEei-YvDU9wix2w" target="_ryJOI3PGEei-YvDU9wix2w">
     <children xmi:type="notation:DecorationNode" xmi:id="_vdhTtHPGEei-YvDU9wix2w" type="6001">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_vdhTtXPGEei-YvDU9wix2w" x="2" y="21"/>
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_vdhTtXPGEei-YvDU9wix2w" x="5" y="18"/>
     </children>
     <children xmi:type="notation:DecorationNode" xmi:id="_vdhTtnPGEei-YvDU9wix2w" type="6002">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_vdhTt3PGEei-YvDU9wix2w" x="13" y="26"/>
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_vdhTt3PGEei-YvDU9wix2w" x="25" y="21"/>
     </children>
     <styles xmi:type="notation:FontStyle" xmi:id="_vdhTsnPGEei-YvDU9wix2w" fontName="Segoe UI"/>
     <element xmi:type="henshin:Edge" href="pls.henshin#_vdhTsHPGEei-YvDU9wix2w"/>
@@ -347,15 +267,16 @@
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_vpJU4XPGEei-YvDU9wix2w" type="4001" source="_q0eE83PGEei-YvDU9wix2w" target="_sO5bkHPGEei-YvDU9wix2w">
     <children xmi:type="notation:DecorationNode" xmi:id="_vpJU5HPGEei-YvDU9wix2w" type="6001">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_vpJU5XPGEei-YvDU9wix2w" x="20" y="20"/>
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_vpJU5XPGEei-YvDU9wix2w" x="8" y="16"/>
     </children>
     <children xmi:type="notation:DecorationNode" xmi:id="_vpJU5nPGEei-YvDU9wix2w" type="6002">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_vpJU53PGEei-YvDU9wix2w" x="-20" y="-9"/>
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_vpJU53PGEei-YvDU9wix2w" x="8" y="-27"/>
     </children>
     <styles xmi:type="notation:FontStyle" xmi:id="_vpJU4nPGEei-YvDU9wix2w" fontName="Segoe UI"/>
     <element xmi:type="henshin:Edge" href="pls.henshin#_vpJU4HPGEei-YvDU9wix2w"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_vpJU43PGEei-YvDU9wix2w" points="[31, 0, -17, -38]$[48, 0, 0, -38]$[48, 37, 0, -1]"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lU5doMz7EeqKm4qRwgovQA" id="(0.12727272727272726,0.023809523809523808)"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_vpJU43PGEei-YvDU9wix2w" points="[4, -1, 0, 30]$[4, -12, 0, 19]$[4, -29, 0, 2]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jZDjoDo2Eeur_rEWBAksIg" id="(0.26229508196721313,0.023809523809523808)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lU5doMz7EeqKm4qRwgovQA" id="(0.34545454545454546,0.9523809523809523)"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_v3GRUnPGEei-YvDU9wix2w" type="4001" source="_pC9rEHPGEei-YvDU9wix2w" target="_qM02I3PGEei-YvDU9wix2w">
     <children xmi:type="notation:DecorationNode" xmi:id="_v3GRVXPGEei-YvDU9wix2w" type="6001">
@@ -370,15 +291,15 @@
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_wFFC8nPGEei-YvDU9wix2w" type="4001" source="_pC9rEHPGEei-YvDU9wix2w" target="_q0eE83PGEei-YvDU9wix2w">
     <children xmi:type="notation:DecorationNode" xmi:id="_wFFC9XPGEei-YvDU9wix2w" type="6001">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_wFFC9nPGEei-YvDU9wix2w" x="2" y="12"/>
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_wFFC9nPGEei-YvDU9wix2w" x="5" y="9"/>
     </children>
     <children xmi:type="notation:DecorationNode" xmi:id="_wFFC93PGEei-YvDU9wix2w" type="6002">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_wFFC-HPGEei-YvDU9wix2w" x="2" y="-33"/>
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_wFFC-HPGEei-YvDU9wix2w" x="7" y="-26"/>
     </children>
     <styles xmi:type="notation:FontStyle" xmi:id="_wFFC83PGEei-YvDU9wix2w" fontName="Segoe UI"/>
     <element xmi:type="henshin:Edge" href="pls.henshin#_wFFC8HPGEei-YvDU9wix2w"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_wFFC9HPGEei-YvDU9wix2w" points="[32, 0, -59, -7]$[46, 0, -45, -7]$[71, 0, -20, -7]"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wFFC-XPGEei-YvDU9wix2w" id="(0.03278688524590164,0.6904761904761905)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wFFC-XPGEei-YvDU9wix2w" id="(0.03278688524590164,0.5714285714285714)"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_9X6K8nPGEei-YvDU9wix2w" type="4001" source="_7X1wpXPGEei-YvDU9wix2w" target="_8JR0oHPGEei-YvDU9wix2w">
     <children xmi:type="notation:DecorationNode" xmi:id="_9X6K9XPGEei-YvDU9wix2w" type="6001">
@@ -415,44 +336,5 @@
     <element xmi:type="henshin:Edge" href="pls.henshin#_97gAMHPGEei-YvDU9wix2w"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_97pKInPGEei-YvDU9wix2w" points="[0, 2, 75, -30]$[0, 32, 75, 0]$[-44, 32, 31, 0]"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_97pKJ3PGEei-YvDU9wix2w" id="(0.5573770491803278,0.9523809523809523)"/>
-  </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_RrZcAYUPEei0FfH_M_cW1g" type="4001" source="_QCVzgIUPEei0FfH_M_cW1g" target="_rdUNo3PGEei-YvDU9wix2w">
-    <children xmi:type="notation:DecorationNode" xmi:id="_RrZcBIUPEei0FfH_M_cW1g" type="6001">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_RrZcBYUPEei0FfH_M_cW1g" x="23" y="-10"/>
-    </children>
-    <children xmi:type="notation:DecorationNode" xmi:id="_RrZcBoUPEei0FfH_M_cW1g" type="6002">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_RrZcB4UPEei0FfH_M_cW1g" x="27" y="13"/>
-    </children>
-    <styles xmi:type="notation:FontStyle" xmi:id="_RrZcAoUPEei0FfH_M_cW1g" fontName="Segoe UI"/>
-    <element xmi:type="henshin:Edge" href="pls.henshin#_RrY08IUPEei0FfH_M_cW1g"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_RrZcA4UPEei0FfH_M_cW1g" points="[-2, -4, 158, 0]$[-80, -4, 80, 0]$[-129, -4, 31, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RrZcCIUPEei0FfH_M_cW1g" id="(0.01639344262295082,0.5476190476190477)"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RrZcCYUPEei0FfH_M_cW1g" id="(0.9387755102040817,0.5238095238095238)"/>
-  </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_R-ohEYUPEei0FfH_M_cW1g" type="4001" source="_QCVzgIUPEei0FfH_M_cW1g" target="_sO5bkHPGEei-YvDU9wix2w">
-    <children xmi:type="notation:DecorationNode" xmi:id="_R-ohFIUPEei0FfH_M_cW1g" type="6001">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_R-ohFYUPEei0FfH_M_cW1g" x="-31" y="27"/>
-    </children>
-    <children xmi:type="notation:DecorationNode" xmi:id="_R-ohFoUPEei0FfH_M_cW1g" type="6002">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_R-ohF4UPEei0FfH_M_cW1g" x="-22" y="23"/>
-    </children>
-    <styles xmi:type="notation:FontStyle" xmi:id="_R-ohEoUPEei0FfH_M_cW1g" fontName="Segoe UI"/>
-    <element xmi:type="henshin:Edge" href="pls.henshin#_R-ohEIUPEei0FfH_M_cW1g"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_R-ohE4UPEei0FfH_M_cW1g" points="[15, 21, -35, -49]$[35, 49, -15, -21]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eDBygMz7EeqKm4qRwgovQA" id="(0.8278688524590164,0.9761904761904762)"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nXRlEMz7EeqKm4qRwgovQA" id="(0.8181818181818182,0.023809523809523808)"/>
-  </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_lCuAkIUQEeix5NK6BRBUTA" type="4001" source="_QCVzgIUPEei0FfH_M_cW1g" target="_ryJOI3PGEei-YvDU9wix2w">
-    <children xmi:type="notation:DecorationNode" xmi:id="_lCuAk4UQEeix5NK6BRBUTA" type="6001">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_lCuAlIUQEeix5NK6BRBUTA" x="25" y="-9"/>
-    </children>
-    <children xmi:type="notation:DecorationNode" xmi:id="_lCuAlYUQEeix5NK6BRBUTA" type="6002">
-      <layoutConstraint xmi:type="notation:Location" xmi:id="_lCuAloUQEeix5NK6BRBUTA" x="30" y="10"/>
-    </children>
-    <styles xmi:type="notation:FontStyle" xmi:id="_lCuAkYUQEeix5NK6BRBUTA" fontName="Segoe UI"/>
-    <element xmi:type="henshin:Edge" href="pls.henshin#_lCqWMIUQEeix5NK6BRBUTA"/>
-    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lCuAkoUQEeix5NK6BRBUTA" points="[0, 5, 92, -22]$[0, 27, 92, 0]$[-91, 27, 1, 0]"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KoeeUMz7EeqKm4qRwgovQA" id="(0.11475409836065574,0.8809523809523809)"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lC0uQIUQEeix5NK6BRBUTA" id="(0.9795918367346939,0.40476190476190477)"/>
   </edges>
 </notation:Diagram>

--- a/uk.ac.kcl.inf.modelling.pls.model.edit/META-INF/MANIFEST.MF
+++ b/uk.ac.kcl.inf.modelling.pls.model.edit/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: uk.ac.kcl.inf.modelling.pls.model.edit;singleton:=true
+Automatic-Module-Name: uk.ac.kcl.inf.modelling.pls.model.edit
 Bundle-Version: 1.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: uk.ac.kcl.inf.modelling.pls.pls.provider.ModelEditPlugin$Implementation

--- a/uk.ac.kcl.inf.modelling.pls.model.edit/plugin.properties
+++ b/uk.ac.kcl.inf.modelling.pls.model.edit/plugin.properties
@@ -39,3 +39,5 @@ _UI_Conveyor_tray_feature = Tray
 _UI_NamedElement_name_feature = Name
 _UI_Unknown_feature = Unspecified
 
+_UI_ProductionLineModel_machines_feature = Machines
+_UI_ProductionLineModel_containers_feature = Containers

--- a/uk.ac.kcl.inf.modelling.pls.model.edit/src-gen/uk/ac/kcl/inf/modelling/pls/pls/provider/ContainerItemProvider.java
+++ b/uk.ac.kcl.inf.modelling.pls.model.edit/src-gen/uk/ac/kcl/inf/modelling/pls/pls/provider/ContainerItemProvider.java
@@ -8,10 +8,13 @@ import java.util.List;
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 
+import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
 
+import org.eclipse.emf.edit.provider.ViewerNotification;
 import uk.ac.kcl.inf.modelling.pls.pls.Container;
+import uk.ac.kcl.inf.modelling.pls.pls.PLSFactory;
 import uk.ac.kcl.inf.modelling.pls.pls.PLSPackage;
 
 /**
@@ -63,6 +66,36 @@ public class ContainerItemProvider extends NamedElementItemProvider {
 	}
 
 	/**
+	 * This specifies how to implement {@link #getChildren} and is used to deduce an appropriate feature for an
+	 * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
+	 * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public Collection<? extends EStructuralFeature> getChildrenFeatures(Object object) {
+		if (childrenFeatures == null) {
+			super.getChildrenFeatures(object);
+			childrenFeatures.add(PLSPackage.Literals.CONTAINER__PARTS);
+		}
+		return childrenFeatures;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	protected EStructuralFeature getChildFeature(Object object, Object child) {
+		// Check the type of the specified child object and return the proper feature to use for
+		// adding (see {@link AddCommand}) it as a child.
+
+		return super.getChildFeature(object, child);
+	}
+
+	/**
 	 * This returns Container.gif.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -106,6 +139,12 @@ public class ContainerItemProvider extends NamedElementItemProvider {
 	@Override
 	public void notifyChanged(Notification notification) {
 		updateChildren(notification);
+
+		switch (notification.getFeatureID(Container.class)) {
+		case PLSPackage.CONTAINER__PARTS:
+			fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
+			return;
+		}
 		super.notifyChanged(notification);
 	}
 
@@ -119,6 +158,18 @@ public class ContainerItemProvider extends NamedElementItemProvider {
 	@Override
 	protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
 		super.collectNewChildDescriptors(newChildDescriptors, object);
+
+		newChildDescriptors
+				.add(createChildParameter(PLSPackage.Literals.CONTAINER__PARTS, PLSFactory.eINSTANCE.createPart()));
+
+		newChildDescriptors
+				.add(createChildParameter(PLSPackage.Literals.CONTAINER__PARTS, PLSFactory.eINSTANCE.createHammer()));
+
+		newChildDescriptors
+				.add(createChildParameter(PLSPackage.Literals.CONTAINER__PARTS, PLSFactory.eINSTANCE.createHead()));
+
+		newChildDescriptors
+				.add(createChildParameter(PLSPackage.Literals.CONTAINER__PARTS, PLSFactory.eINSTANCE.createHandle()));
 	}
 
 }

--- a/uk.ac.kcl.inf.modelling.pls.model.edit/src-gen/uk/ac/kcl/inf/modelling/pls/pls/provider/ProductionLineModelItemProvider.java
+++ b/uk.ac.kcl.inf.modelling.pls.model.edit/src-gen/uk/ac/kcl/inf/modelling/pls/pls/provider/ProductionLineModelItemProvider.java
@@ -70,7 +70,8 @@ public class ProductionLineModelItemProvider extends ItemProviderAdapter impleme
 	public Collection<? extends EStructuralFeature> getChildrenFeatures(Object object) {
 		if (childrenFeatures == null) {
 			super.getChildrenFeatures(object);
-			childrenFeatures.add(PLSPackage.Literals.PRODUCTION_LINE_MODEL__ELEMENTS);
+			childrenFeatures.add(PLSPackage.Literals.PRODUCTION_LINE_MODEL__MACHINES);
+			childrenFeatures.add(PLSPackage.Literals.PRODUCTION_LINE_MODEL__CONTAINERS);
 		}
 		return childrenFeatures;
 	}
@@ -132,7 +133,8 @@ public class ProductionLineModelItemProvider extends ItemProviderAdapter impleme
 		updateChildren(notification);
 
 		switch (notification.getFeatureID(ProductionLineModel.class)) {
-		case PLSPackage.PRODUCTION_LINE_MODEL__ELEMENTS:
+		case PLSPackage.PRODUCTION_LINE_MODEL__MACHINES:
+		case PLSPackage.PRODUCTION_LINE_MODEL__CONTAINERS:
 			fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
 			return;
 		}
@@ -150,44 +152,32 @@ public class ProductionLineModelItemProvider extends ItemProviderAdapter impleme
 	protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
 		super.collectNewChildDescriptors(newChildDescriptors, object);
 
-		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__ELEMENTS,
+		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__MACHINES,
 				PLSFactory.eINSTANCE.createMachine()));
 
-		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__ELEMENTS,
-				PLSFactory.eINSTANCE.createContainer()));
-
-		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__ELEMENTS,
-				PLSFactory.eINSTANCE.createPart()));
-
-		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__ELEMENTS,
-				PLSFactory.eINSTANCE.createConveyor()));
-
-		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__ELEMENTS,
-				PLSFactory.eINSTANCE.createTray()));
-
-		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__ELEMENTS,
-				PLSFactory.eINSTANCE.createHammer()));
-
-		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__ELEMENTS,
-				PLSFactory.eINSTANCE.createHead()));
-
-		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__ELEMENTS,
-				PLSFactory.eINSTANCE.createHandle()));
-
-		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__ELEMENTS,
+		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__MACHINES,
 				PLSFactory.eINSTANCE.createPolisher()));
 
-		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__ELEMENTS,
+		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__MACHINES,
 				PLSFactory.eINSTANCE.createAssembler()));
 
-		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__ELEMENTS,
+		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__MACHINES,
 				PLSFactory.eINSTANCE.createGenerator()));
 
-		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__ELEMENTS,
+		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__MACHINES,
 				PLSFactory.eINSTANCE.createGenHead()));
 
-		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__ELEMENTS,
+		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__MACHINES,
 				PLSFactory.eINSTANCE.createGenHandle()));
+
+		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__CONTAINERS,
+				PLSFactory.eINSTANCE.createContainer()));
+
+		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__CONTAINERS,
+				PLSFactory.eINSTANCE.createConveyor()));
+
+		newChildDescriptors.add(createChildParameter(PLSPackage.Literals.PRODUCTION_LINE_MODEL__CONTAINERS,
+				PLSFactory.eINSTANCE.createTray()));
 	}
 
 	/**

--- a/uk.ac.kcl.inf.modelling.pls.model.editor/META-INF/MANIFEST.MF
+++ b/uk.ac.kcl.inf.modelling.pls.model.editor/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: uk.ac.kcl.inf.modelling.pls.model.editor;singleton:=true
+Automatic-Module-Name: uk.ac.kcl.inf.modelling.pls.model.editor
 Bundle-Version: 1.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: uk.ac.kcl.inf.modelling.pls.pls.presentation.ModelEditorPlugin$Implementation

--- a/uk.ac.kcl.inf.modelling.pls.model.editor/src-gen/uk/ac/kcl/inf/modelling/pls/pls/presentation/PLSActionBarContributor.java
+++ b/uk.ac.kcl.inf.modelling.pls.model.editor/src-gen/uk/ac/kcl/inf/modelling/pls/pls/presentation/PLSActionBarContributor.java
@@ -160,6 +160,7 @@ public class PLSActionBarContributor extends EditingDomainActionBarContributor i
 	 */
 	@Override
 	public void contributeToToolBar(IToolBarManager toolBarManager) {
+		super.contributeToToolBar(toolBarManager);
 		toolBarManager.add(new Separator("pls-settings"));
 		toolBarManager.add(new Separator("pls-additions"));
 	}

--- a/uk.ac.kcl.inf.modelling.pls.model/META-INF/MANIFEST.MF
+++ b/uk.ac.kcl.inf.modelling.pls.model/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: uk.ac.kcl.inf.modelling.pls.model;singleton:=true
+Automatic-Module-Name: uk.ac.kcl.inf.modelling.pls.model
 Bundle-Version: 0.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName

--- a/uk.ac.kcl.inf.modelling.pls.model/model/model.aird
+++ b/uk.ac.kcl.inf.modelling.pls.model/model/model.aird
@@ -14,12 +14,12 @@
   <diagram:DSemanticDiagram uid="_6rwd0HOyEei1suQ1831VIg" name="model">
     <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_6rwd0XOyEei1suQ1831VIg" source="DANNOTATION_CUSTOMIZATION_KEY">
       <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_6rwd0nOyEei1suQ1831VIg">
-        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_yBCT8XOzEei1suQ1831VIg" sourceArrow="FillDiamond" routingStyle="manhattan">
+        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_hv0cUDozEeuKkshwNXIjOg" sourceArrow="FillDiamond" routingStyle="manhattan">
           <strokeColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
-          <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_yBCT8nOzEei1suQ1831VIg" showIcon="false" labelExpression="service:render">
+          <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_hv0cUTozEeuKkshwNXIjOg" showIcon="false" labelExpression="service:render">
             <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
           </centerLabelStyleDescription>
-          <endLabelStyleDescription xmi:type="style:EndLabelStyleDescription" xmi:id="_yBCT83OzEei1suQ1831VIg" labelSize="6" showIcon="false" labelExpression="service:eKeysLabel">
+          <endLabelStyleDescription xmi:type="style:EndLabelStyleDescription" xmi:id="_hv0cUjozEeuKkshwNXIjOg" labelSize="6" showIcon="false" labelExpression="service:eKeysLabel">
             <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_blue']"/>
           </endLabelStyleDescription>
         </computedStyleDescriptions>
@@ -43,7 +43,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_Lls2d3OzEei1suQ1831VIg"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_Lls2cnOzEei1suQ1831VIg" fontName="Segoe UI" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Lls2c3OzEei1suQ1831VIg" x="235" y="245" width="120" height="48"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Lls2c3OzEei1suQ1831VIg" x="235" y="255" width="120" height="48"/>
         </children>
         <children xmi:type="notation:Node" xmi:id="_M0N4AXOzEei1suQ1831VIg" type="2003" element="_M0EHAHOzEei1suQ1831VIg">
           <children xmi:type="notation:Node" xmi:id="_M0N4BHOzEei1suQ1831VIg" type="5007"/>
@@ -70,7 +70,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_RQGNeHOzEei1suQ1831VIg"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_RQGNc3OzEei1suQ1831VIg" fontName="Segoe UI" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RQGNdHOzEei1suQ1831VIg" x="410" y="245" width="120" height="48"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RQGNdHOzEei1suQ1831VIg" x="410" y="255" width="120" height="48"/>
         </children>
         <children xmi:type="notation:Node" xmi:id="_SXG40nOzEei1suQ1831VIg" type="2003" element="_SXG40HOzEei1suQ1831VIg">
           <children xmi:type="notation:Node" xmi:id="_SXG41XOzEei1suQ1831VIg" type="5007"/>
@@ -79,7 +79,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_SXG42HOzEei1suQ1831VIg"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_SXG403OzEei1suQ1831VIg" fontName="Segoe UI" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SXG41HOzEei1suQ1831VIg" x="580" y="245" width="120" height="48"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SXG41HOzEei1suQ1831VIg" x="580" y="255" width="120" height="48"/>
         </children>
         <children xmi:type="notation:Node" xmi:id="_S2UkYHOzEei1suQ1831VIg" type="2003" element="_S2KzYHOzEei1suQ1831VIg">
           <children xmi:type="notation:Node" xmi:id="_S2UkY3OzEei1suQ1831VIg" type="5007"/>
@@ -115,7 +115,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_Ydg2aHOzEei1suQ1831VIg"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_Ydg2Y3OzEei1suQ1831VIg" fontName="Segoe UI" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ydg2ZHOzEei1suQ1831VIg" x="252" y="325" width="120" height="48"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ydg2ZHOzEei1suQ1831VIg" x="252" y="335" width="120" height="48"/>
         </children>
         <children xmi:type="notation:Node" xmi:id="_ZjHzknOzEei1suQ1831VIg" type="2003" element="_ZjHzkHOzEei1suQ1831VIg">
           <children xmi:type="notation:Node" xmi:id="_ZjHzlXOzEei1suQ1831VIg" type="5007"/>
@@ -124,7 +124,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_ZjHzmHOzEei1suQ1831VIg"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_ZjHzk3OzEei1suQ1831VIg" fontName="Segoe UI" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZjHzlHOzEei1suQ1831VIg" x="377" y="325" width="120" height="48"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZjHzlHOzEei1suQ1831VIg" x="377" y="335" width="120" height="48"/>
         </children>
         <children xmi:type="notation:Node" xmi:id="_ad8dEHOzEei1suQ1831VIg" type="2003" element="_adyFAHOzEei1suQ1831VIg">
           <children xmi:type="notation:Node" xmi:id="_ad8dE3OzEei1suQ1831VIg" type="5007"/>
@@ -133,7 +133,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_ad8dFnOzEei1suQ1831VIg"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_ad8dEXOzEei1suQ1831VIg" fontName="Segoe UI" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ad8dEnOzEei1suQ1831VIg" x="502" y="325" width="120" height="48"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ad8dEnOzEei1suQ1831VIg" x="502" y="335" width="120" height="48"/>
         </children>
         <children xmi:type="notation:Node" xmi:id="_bxjaAnOzEei1suQ1831VIg" type="2003" element="_bxjaAHOzEei1suQ1831VIg">
           <children xmi:type="notation:Node" xmi:id="_bxjaBXOzEei1suQ1831VIg" type="5007"/>
@@ -142,7 +142,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_bxjaCHOzEei1suQ1831VIg"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_bxjaA3OzEei1suQ1831VIg" fontName="Segoe UI" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bxjaBHOzEei1suQ1831VIg" x="680" y="305" width="120" height="38"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bxjaBHOzEei1suQ1831VIg" x="680" y="315" width="120" height="38"/>
         </children>
         <children xmi:type="notation:Node" xmi:id="_cxRxoHOzEei1suQ1831VIg" type="2003" element="_cxIAoHOzEei1suQ1831VIg">
           <children xmi:type="notation:Node" xmi:id="_cxSYsHOzEei1suQ1831VIg" type="5007"/>
@@ -151,7 +151,7 @@
             <styles xmi:type="notation:FilteringStyle" xmi:id="_cxSYs3OzEei1suQ1831VIg"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_cxRxoXOzEei1suQ1831VIg" fontName="Segoe UI" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cxRxonOzEei1suQ1831VIg" x="680" y="350" width="120" height="40"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cxRxonOzEei1suQ1831VIg" x="680" y="360" width="120" height="40"/>
         </children>
         <children xmi:type="notation:Node" xmi:id="_vKwDUnOzEei1suQ1831VIg" type="2003" element="_vKwDUHOzEei1suQ1831VIg">
           <children xmi:type="notation:Node" xmi:id="_vK50UHOzEei1suQ1831VIg" type="5007"/>
@@ -439,25 +439,41 @@
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xROnpnOzEei1suQ1831VIg" id="(0.44166666666666665,0.042608695652173914)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xROnp3OzEei1suQ1831VIg" id="(0.5,0.9607843137254902)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_yBME8HOzEei1suQ1831VIg" type="4001" element="_yBCT8HOzEei1suQ1831VIg" source="__861cHOyEei1suQ1831VIg" target="_vKwDUnOzEei1suQ1831VIg">
-          <children xmi:type="notation:Node" xmi:id="_yBME9HOzEei1suQ1831VIg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yBME9XOzEei1suQ1831VIg" y="-9"/>
+        <edges xmi:type="notation:Edge" xmi:id="_hwX18DozEeuKkshwNXIjOg" type="4001" element="_hvzOMDozEeuKkshwNXIjOg" source="__861cHOyEei1suQ1831VIg" target="_Lls2cXOzEei1suQ1831VIg">
+          <children xmi:type="notation:Node" xmi:id="_hwdVgDozEeuKkshwNXIjOg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hwdVgTozEeuKkshwNXIjOg" x="30" y="41"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_yBME9nOzEei1suQ1831VIg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yBME93OzEei1suQ1831VIg" x="-3" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_hwd8kDozEeuKkshwNXIjOg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hwd8kTozEeuKkshwNXIjOg" x="-2" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_yBME-HOzEei1suQ1831VIg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yBME-XOzEei1suQ1831VIg" x="-34" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_hwd8kjozEeuKkshwNXIjOg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hwd8kzozEeuKkshwNXIjOg" x="-8" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_yBME8XOzEei1suQ1831VIg" routing="Rectilinear"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_yBME8nOzEei1suQ1831VIg" fontColor="7490599" fontName="Segoe UI" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yBME83OzEei1suQ1831VIg" points="[0, -1, -78, -24]$[78, -1, 0, -24]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yBME-nOzEei1suQ1831VIg" id="(1.0,0.5098039215686274)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yBME-3OzEei1suQ1831VIg" id="(0.0,0.9607843137254902)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_hwX18TozEeuKkshwNXIjOg" routing="Rectilinear"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_hwX18jozEeuKkshwNXIjOg" fontColor="7490599" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hwX18zozEeuKkshwNXIjOg" points="[0, 0, 0, -99]$[0, 99, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hwgY0DozEeuKkshwNXIjOg" id="(0.13259668508287292,1.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hwg_4DozEeuKkshwNXIjOg" id="(0.2033898305084746,0.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_lBj54DozEeuKkshwNXIjOg" type="4001" element="_lBN7oDozEeuKkshwNXIjOg" source="__861cHOyEei1suQ1831VIg" target="_M0N4AXOzEei1suQ1831VIg">
+          <children xmi:type="notation:Node" xmi:id="_lBj55DozEeuKkshwNXIjOg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lBj55TozEeuKkshwNXIjOg" x="18" y="13"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lBj55jozEeuKkshwNXIjOg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lBj55zozEeuKkshwNXIjOg" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_lBj56DozEeuKkshwNXIjOg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lBj56TozEeuKkshwNXIjOg" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_lBj54TozEeuKkshwNXIjOg" routing="Rectilinear"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_lBj54jozEeuKkshwNXIjOg" fontColor="7490599" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lBj54zozEeuKkshwNXIjOg" points="[0, 0, -26, -47]$[0, 47, -26, 0]$[26, 47, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lBkg8DozEeuKkshwNXIjOg" id="(0.7403314917127072,1.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lBkg8TozEeuKkshwNXIjOg" id="(0.0,0.5)"/>
         </edges>
       </data>
     </ownedAnnotationEntries>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="__8U_kHOyEei1suQ1831VIg" name="ProductionLineModel" tooltipText="" outgoingEdges="_yBCT8HOzEei1suQ1831VIg" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="__8U_kHOyEei1suQ1831VIg" name="ProductionLineModel" tooltipText="" outgoingEdges="_hvzOMDozEeuKkshwNXIjOg _lBN7oDozEeuKkshwNXIjOg" width="12" height="10">
       <target xmi:type="ecore:EClass" href="model.ecore#//ProductionLineModel"/>
       <semanticElements xmi:type="ecore:EClass" href="model.ecore#//ProductionLineModel"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
@@ -468,7 +484,7 @@
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_LlsPYHOzEei1suQ1831VIg" name="Machine" tooltipText="" outgoingEdges="_lITG8HOzEei1suQ1831VIg _lgRiEHOzEei1suQ1831VIg _wzIWYHOzEei1suQ1831VIg" incomingEdges="_fGIwMHOzEei1suQ1831VIg _fe-uAHOzEei1suQ1831VIg _f2iSYHOzEei1suQ1831VIg" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_LlsPYHOzEei1suQ1831VIg" name="Machine" tooltipText="" outgoingEdges="_lITG8HOzEei1suQ1831VIg _lgRiEHOzEei1suQ1831VIg _wzIWYHOzEei1suQ1831VIg" incomingEdges="_fGIwMHOzEei1suQ1831VIg _fe-uAHOzEei1suQ1831VIg _f2iSYHOzEei1suQ1831VIg _hvzOMDozEeuKkshwNXIjOg" width="12" height="10">
       <target xmi:type="ecore:EClass" href="model.ecore#//Machine"/>
       <semanticElements xmi:type="ecore:EClass" href="model.ecore#//Machine"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
@@ -479,7 +495,7 @@
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_M0EHAHOzEei1suQ1831VIg" name="Container" tooltipText="" outgoingEdges="_oAJd0HOzEei1suQ1831VIg _w_-fkHOzEei1suQ1831VIg" incomingEdges="_grVMYHOzEei1suQ1831VIg _g8EXEHOzEei1suQ1831VIg" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_M0EHAHOzEei1suQ1831VIg" name="Container" tooltipText="" outgoingEdges="_oAJd0HOzEei1suQ1831VIg _w_-fkHOzEei1suQ1831VIg" incomingEdges="_grVMYHOzEei1suQ1831VIg _g8EXEHOzEei1suQ1831VIg _lBN7oDozEeuKkshwNXIjOg" width="12" height="10">
       <target xmi:type="ecore:EClass" href="model.ecore#//Container"/>
       <semanticElements xmi:type="ecore:EClass" href="model.ecore#//Container"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
@@ -781,18 +797,13 @@
     <ownedDiagramElements xmi:type="diagram:DEdge" uid="_oAJd0HOzEei1suQ1831VIg" name="[0..*] parts" sourceNode="_M0EHAHOzEei1suQ1831VIg" targetNode="_Of-2QHOzEei1suQ1831VIg">
       <target xmi:type="ecore:EReference" href="model.ecore#//Container/parts"/>
       <semanticElements xmi:type="ecore:EReference" href="model.ecore#//Container/parts"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_oAJd0XOzEei1suQ1831VIg" routingStyle="manhattan" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_oAJd0nOzEei1suQ1831VIg" showIcon="false">
-          <customFeatures>labelSize</customFeatures>
-        </centerLabelStyle>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_oAJd03OzEei1suQ1831VIg" showIcon="false" labelColor="39,76,114">
-          <customFeatures>labelSize</customFeatures>
-        </endLabelStyle>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_uxIWgDozEeuKkshwNXIjOg" description="_hv0cUDozEeuKkshwNXIjOg" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_uxIWgjozEeuKkshwNXIjOg" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_uxIWgTozEeuKkshwNXIjOg" labelSize="6" showIcon="false" labelColor="39,76,114"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_vKwDUHOzEei1suQ1831VIg" name="NamedElement" tooltipText="" incomingEdges="_wzIWYHOzEei1suQ1831VIg _w_-fkHOzEei1suQ1831VIg _xQ53gHOzEei1suQ1831VIg _yBCT8HOzEei1suQ1831VIg" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_vKwDUHOzEei1suQ1831VIg" name="NamedElement" tooltipText="" incomingEdges="_wzIWYHOzEei1suQ1831VIg _w_-fkHOzEei1suQ1831VIg _xQ53gHOzEei1suQ1831VIg" width="12" height="10">
       <target xmi:type="ecore:EClass" href="model.ecore#//NamedElement"/>
       <semanticElements xmi:type="ecore:EClass" href="model.ecore#//NamedElement"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
@@ -848,14 +859,27 @@
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_yBCT8HOzEei1suQ1831VIg" name="[0..*] elements" sourceNode="__8U_kHOyEei1suQ1831VIg" targetNode="_vKwDUHOzEei1suQ1831VIg">
-      <target xmi:type="ecore:EReference" href="model.ecore#//ProductionLineModel/elements"/>
-      <semanticElements xmi:type="ecore:EReference" href="model.ecore#//ProductionLineModel/elements"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_yBCT9HOzEei1suQ1831VIg" description="_yBCT8XOzEei1suQ1831VIg" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_yBCT9XOzEei1suQ1831VIg" showIcon="false">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_hvzOMDozEeuKkshwNXIjOg" name="[0..*] machines" sourceNode="__8U_kHOyEei1suQ1831VIg" targetNode="_LlsPYHOzEei1suQ1831VIg">
+      <target xmi:type="ecore:EReference" href="model.ecore#//ProductionLineModel/machines"/>
+      <semanticElements xmi:type="ecore:EReference" href="model.ecore#//ProductionLineModel/machines"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_hv0cUzozEeuKkshwNXIjOg" description="_hv0cUDozEeuKkshwNXIjOg" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_hv0cVTozEeuKkshwNXIjOg" showIcon="false">
           <customFeatures>labelSize</customFeatures>
         </centerLabelStyle>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_yBCT9nOzEei1suQ1831VIg" showIcon="false" labelColor="39,76,114">
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_hv0cVDozEeuKkshwNXIjOg" showIcon="false" labelColor="39,76,114">
+          <customFeatures>labelSize</customFeatures>
+        </endLabelStyle>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_lBN7oDozEeuKkshwNXIjOg" name="[0..*] containers" sourceNode="__8U_kHOyEei1suQ1831VIg" targetNode="_M0EHAHOzEei1suQ1831VIg">
+      <target xmi:type="ecore:EReference" href="model.ecore#//ProductionLineModel/containers"/>
+      <semanticElements xmi:type="ecore:EReference" href="model.ecore#//ProductionLineModel/containers"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_lBOisDozEeuKkshwNXIjOg" description="_hv0cUDozEeuKkshwNXIjOg" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_lBOisjozEeuKkshwNXIjOg" showIcon="false">
+          <customFeatures>labelSize</customFeatures>
+        </centerLabelStyle>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_lBOisTozEeuKkshwNXIjOg" showIcon="false" labelColor="39,76,114">
           <customFeatures>labelSize</customFeatures>
         </endLabelStyle>
       </ownedStyle>

--- a/uk.ac.kcl.inf.modelling.pls.model/model/model.ecore
+++ b/uk.ac.kcl.inf.modelling.pls.model/model/model.ecore
@@ -2,10 +2,10 @@
 <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="pls" nsURI="https://inf.kcl.ac.uk/models/pls" nsPrefix="pls">
   <eClassifiers xsi:type="ecore:EClass" name="ProductionLineModel">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="elements" upperBound="-1"
-        eType="#//NamedElement" containment="true">
-      <eAnnotations source="aspect"/>
-    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="machines" upperBound="-1"
+        eType="#//Machine" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="containers" upperBound="-1"
+        eType="#//Container" containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Machine" eSuperTypes="#//NamedElement">
     <eStructuralFeatures xsi:type="ecore:EReference" name="out" eType="#//Conveyor"/>
@@ -13,7 +13,7 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Container" eSuperTypes="#//NamedElement">
     <eStructuralFeatures xsi:type="ecore:EReference" name="parts" upperBound="-1"
-        eType="#//Part">
+        eType="#//Part" containment="true">
       <eAnnotations source="aspect"/>
     </eStructuralFeatures>
   </eClassifiers>

--- a/uk.ac.kcl.inf.modelling.pls.model/model/model.genmodel
+++ b/uk.ac.kcl.inf.modelling.pls.model/model/model.genmodel
@@ -1,71 +1,41 @@
 <?xml version="1.0" encoding="ASCII"?>
-<genmodel:GenModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/uk.ac.kcl.inf.modelling.pls.model/src-gen" creationIcons="false" editDirectory="/uk.ac.kcl.inf.modelling.pls.model.edit/src-gen" editorDirectory="/uk.ac.kcl.inf.modelling.pls.model.editor/src-gen" modelPluginID="uk.ac.kcl.inf.modelling.pls.model" modelName="Model" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container" codeFormatting="true" importerID="org.eclipse.emf.importer.ecore" complianceLevel="8.0" copyrightFields="false" operationReflection="true" importOrganizing="true">
+<genmodel:GenModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel"
+    modelDirectory="/uk.ac.kcl.inf.modelling.pls.model/src-gen" creationIcons="false"
+    editDirectory="/uk.ac.kcl.inf.modelling.pls.model.edit/src-gen" editorDirectory="/uk.ac.kcl.inf.modelling.pls.model.editor/src-gen"
+    modelPluginID="uk.ac.kcl.inf.modelling.pls.model" modelName="Model" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
+    codeFormatting="true" importerID="org.eclipse.emf.importer.ecore" complianceLevel="8.0"
+    copyrightFields="false" operationReflection="true" importOrganizing="true">
   <foreignModel>model.ecore</foreignModel>
   <testsDirectory xsi:nil="true"/>
-  <genPackages prefix="PLS" basePackage="uk.ac.kcl.inf.modelling.pls" disposableProviderFactory="true" fileExtensions="pls">
-    <ecorePackage href="model.ecore#/"/>
-    <genClasses>
-      <ecoreClass href="model.ecore#//ProductionLineModel"/>
-      <genFeatures property="None" children="true" createChild="true">
-        <ecoreFeature xsi:type="ecore:EReference" href="model.ecore#//ProductionLineModel/elements"/>
-      </genFeatures>
+  <genPackages prefix="PLS" basePackage="uk.ac.kcl.inf.modelling.pls" disposableProviderFactory="true"
+      fileExtensions="pls" ecorePackage="model.ecore#/">
+    <genClasses ecoreClass="model.ecore#//ProductionLineModel">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference model.ecore#//ProductionLineModel/machines"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference model.ecore#//ProductionLineModel/containers"/>
     </genClasses>
-    <genClasses>
-      <ecoreClass href="model.ecore#//Machine"/>
-      <genFeatures notify="false" createChild="false" propertySortChoices="true">
-        <ecoreFeature xsi:type="ecore:EReference" href="model.ecore#//Machine/out"/>
-      </genFeatures>
-      <genFeatures notify="false" createChild="false" propertySortChoices="true">
-        <ecoreFeature xsi:type="ecore:EReference" href="model.ecore#//Machine/in"/>
-      </genFeatures>
+    <genClasses ecoreClass="model.ecore#//Machine">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference model.ecore#//Machine/out"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference model.ecore#//Machine/in"/>
     </genClasses>
-    <genClasses>
-      <ecoreClass href="model.ecore#//Container"/>
-      <genFeatures notify="false" createChild="false" propertySortChoices="true">
-        <ecoreFeature xsi:type="ecore:EReference" href="model.ecore#//Container/parts"/>
-      </genFeatures>
+    <genClasses ecoreClass="model.ecore#//Container">
+      <genFeatures children="true" createChild="true" propertySortChoices="true" ecoreFeature="ecore:EReference model.ecore#//Container/parts"/>
     </genClasses>
-    <genClasses>
-      <ecoreClass href="model.ecore#//Part"/>
+    <genClasses ecoreClass="model.ecore#//Part"/>
+    <genClasses ecoreClass="model.ecore#//Conveyor">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference model.ecore#//Conveyor/tray"/>
     </genClasses>
-    <genClasses>
-      <ecoreClass href="model.ecore#//Conveyor"/>
-      <genFeatures notify="false" createChild="false" propertySortChoices="true">
-        <ecoreFeature xsi:type="ecore:EReference" href="model.ecore#//Conveyor/tray"/>
-      </genFeatures>
-    </genClasses>
-    <genClasses>
-      <ecoreClass href="model.ecore#//Tray"/>
-    </genClasses>
-    <genClasses>
-      <ecoreClass href="model.ecore#//Hammer"/>
-    </genClasses>
-    <genClasses>
-      <ecoreClass href="model.ecore#//Head"/>
-    </genClasses>
-    <genClasses>
-      <ecoreClass href="model.ecore#//Handle"/>
-    </genClasses>
-    <genClasses>
-      <ecoreClass href="model.ecore#//Polisher"/>
-    </genClasses>
-    <genClasses>
-      <ecoreClass href="model.ecore#//Assembler"/>
-    </genClasses>
-    <genClasses>
-      <ecoreClass href="model.ecore#//Generator"/>
-    </genClasses>
-    <genClasses>
-      <ecoreClass href="model.ecore#//GenHead"/>
-    </genClasses>
-    <genClasses>
-      <ecoreClass href="model.ecore#//GenHandle"/>
-    </genClasses>
-    <genClasses>
-      <ecoreClass href="model.ecore#//NamedElement"/>
-      <genFeatures createChild="false">
-        <ecoreFeature xsi:type="ecore:EAttribute" href="model.ecore#//NamedElement/name"/>
-      </genFeatures>
+    <genClasses ecoreClass="model.ecore#//Tray"/>
+    <genClasses ecoreClass="model.ecore#//Hammer"/>
+    <genClasses ecoreClass="model.ecore#//Head"/>
+    <genClasses ecoreClass="model.ecore#//Handle"/>
+    <genClasses ecoreClass="model.ecore#//Polisher"/>
+    <genClasses ecoreClass="model.ecore#//Assembler"/>
+    <genClasses ecoreClass="model.ecore#//Generator"/>
+    <genClasses ecoreClass="model.ecore#//GenHead"/>
+    <genClasses ecoreClass="model.ecore#//GenHandle"/>
+    <genClasses ecoreClass="model.ecore#//NamedElement">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute model.ecore#//NamedElement/name"/>
     </genClasses>
   </genPackages>
 </genmodel:GenModel>

--- a/uk.ac.kcl.inf.modelling.pls.model/src-gen/uk/ac/kcl/inf/modelling/pls/pls/Container.java
+++ b/uk.ac.kcl.inf.modelling.pls.model/src-gen/uk/ac/kcl/inf/modelling/pls/pls/Container.java
@@ -22,7 +22,7 @@ import org.eclipse.emf.common.util.EList;
  */
 public interface Container extends NamedElement {
 	/**
-	 * Returns the value of the '<em><b>Parts</b></em>' reference list.
+	 * Returns the value of the '<em><b>Parts</b></em>' containment reference list.
 	 * The list contents are of type {@link uk.ac.kcl.inf.modelling.pls.pls.Part}.
 	 * <!-- begin-user-doc -->
 	 * <p>
@@ -30,9 +30,9 @@ public interface Container extends NamedElement {
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Parts</em>' reference list.
+	 * @return the value of the '<em>Parts</em>' containment reference list.
 	 * @see uk.ac.kcl.inf.modelling.pls.pls.PLSPackage#getContainer_Parts()
-	 * @model
+	 * @model containment="true"
 	 * @generated
 	 */
 	EList<Part> getParts();

--- a/uk.ac.kcl.inf.modelling.pls.model/src-gen/uk/ac/kcl/inf/modelling/pls/pls/PLSPackage.java
+++ b/uk.ac.kcl.inf.modelling.pls.model/src-gen/uk/ac/kcl/inf/modelling/pls/pls/PLSPackage.java
@@ -67,13 +67,22 @@ public interface PLSPackage extends EPackage {
 	int PRODUCTION_LINE_MODEL = 0;
 
 	/**
-	 * The feature id for the '<em><b>Elements</b></em>' containment reference list.
+	 * The feature id for the '<em><b>Machines</b></em>' containment reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int PRODUCTION_LINE_MODEL__ELEMENTS = 0;
+	int PRODUCTION_LINE_MODEL__MACHINES = 0;
+
+	/**
+	 * The feature id for the '<em><b>Containers</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PRODUCTION_LINE_MODEL__CONTAINERS = 1;
 
 	/**
 	 * The number of structural features of the '<em>Production Line Model</em>' class.
@@ -82,7 +91,7 @@ public interface PLSPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int PRODUCTION_LINE_MODEL_FEATURE_COUNT = 1;
+	int PRODUCTION_LINE_MODEL_FEATURE_COUNT = 2;
 
 	/**
 	 * The number of operations of the '<em>Production Line Model</em>' class.
@@ -205,7 +214,7 @@ public interface PLSPackage extends EPackage {
 	int CONTAINER__NAME = NAMED_ELEMENT__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Parts</b></em>' reference list.
+	 * The feature id for the '<em><b>Parts</b></em>' containment reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -288,7 +297,7 @@ public interface PLSPackage extends EPackage {
 	int CONVEYOR__NAME = CONTAINER__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Parts</b></em>' reference list.
+	 * The feature id for the '<em><b>Parts</b></em>' containment reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -343,7 +352,7 @@ public interface PLSPackage extends EPackage {
 	int TRAY__NAME = CONTAINER__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Parts</b></em>' reference list.
+	 * The feature id for the '<em><b>Parts</b></em>' containment reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -766,15 +775,26 @@ public interface PLSPackage extends EPackage {
 	EClass getProductionLineModel();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link uk.ac.kcl.inf.modelling.pls.pls.ProductionLineModel#getElements <em>Elements</em>}'.
+	 * Returns the meta object for the containment reference list '{@link uk.ac.kcl.inf.modelling.pls.pls.ProductionLineModel#getMachines <em>Machines</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Elements</em>'.
-	 * @see uk.ac.kcl.inf.modelling.pls.pls.ProductionLineModel#getElements()
+	 * @return the meta object for the containment reference list '<em>Machines</em>'.
+	 * @see uk.ac.kcl.inf.modelling.pls.pls.ProductionLineModel#getMachines()
 	 * @see #getProductionLineModel()
 	 * @generated
 	 */
-	EReference getProductionLineModel_Elements();
+	EReference getProductionLineModel_Machines();
+
+	/**
+	 * Returns the meta object for the containment reference list '{@link uk.ac.kcl.inf.modelling.pls.pls.ProductionLineModel#getContainers <em>Containers</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the containment reference list '<em>Containers</em>'.
+	 * @see uk.ac.kcl.inf.modelling.pls.pls.ProductionLineModel#getContainers()
+	 * @see #getProductionLineModel()
+	 * @generated
+	 */
+	EReference getProductionLineModel_Containers();
 
 	/**
 	 * Returns the meta object for class '{@link uk.ac.kcl.inf.modelling.pls.pls.Machine <em>Machine</em>}'.
@@ -819,10 +839,10 @@ public interface PLSPackage extends EPackage {
 	EClass getContainer();
 
 	/**
-	 * Returns the meta object for the reference list '{@link uk.ac.kcl.inf.modelling.pls.pls.Container#getParts <em>Parts</em>}'.
+	 * Returns the meta object for the containment reference list '{@link uk.ac.kcl.inf.modelling.pls.pls.Container#getParts <em>Parts</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @return the meta object for the reference list '<em>Parts</em>'.
+	 * @return the meta object for the containment reference list '<em>Parts</em>'.
 	 * @see uk.ac.kcl.inf.modelling.pls.pls.Container#getParts()
 	 * @see #getContainer()
 	 * @generated
@@ -1005,12 +1025,20 @@ public interface PLSPackage extends EPackage {
 		EClass PRODUCTION_LINE_MODEL = eINSTANCE.getProductionLineModel();
 
 		/**
-		 * The meta object literal for the '<em><b>Elements</b></em>' containment reference list feature.
+		 * The meta object literal for the '<em><b>Machines</b></em>' containment reference list feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
 		 * @generated
 		 */
-		EReference PRODUCTION_LINE_MODEL__ELEMENTS = eINSTANCE.getProductionLineModel_Elements();
+		EReference PRODUCTION_LINE_MODEL__MACHINES = eINSTANCE.getProductionLineModel_Machines();
+
+		/**
+		 * The meta object literal for the '<em><b>Containers</b></em>' containment reference list feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EReference PRODUCTION_LINE_MODEL__CONTAINERS = eINSTANCE.getProductionLineModel_Containers();
 
 		/**
 		 * The meta object literal for the '{@link uk.ac.kcl.inf.modelling.pls.pls.impl.MachineImpl <em>Machine</em>}' class.
@@ -1049,7 +1077,7 @@ public interface PLSPackage extends EPackage {
 		EClass CONTAINER = eINSTANCE.getContainer();
 
 		/**
-		 * The meta object literal for the '<em><b>Parts</b></em>' reference list feature.
+		 * The meta object literal for the '<em><b>Parts</b></em>' containment reference list feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
 		 * @generated

--- a/uk.ac.kcl.inf.modelling.pls.model/src-gen/uk/ac/kcl/inf/modelling/pls/pls/ProductionLineModel.java
+++ b/uk.ac.kcl.inf.modelling.pls.model/src-gen/uk/ac/kcl/inf/modelling/pls/pls/ProductionLineModel.java
@@ -15,7 +15,8 @@ import org.eclipse.emf.ecore.EObject;
  * The following features are supported:
  * </p>
  * <ul>
- *   <li>{@link uk.ac.kcl.inf.modelling.pls.pls.ProductionLineModel#getElements <em>Elements</em>}</li>
+ *   <li>{@link uk.ac.kcl.inf.modelling.pls.pls.ProductionLineModel#getMachines <em>Machines</em>}</li>
+ *   <li>{@link uk.ac.kcl.inf.modelling.pls.pls.ProductionLineModel#getContainers <em>Containers</em>}</li>
  * </ul>
  *
  * @see uk.ac.kcl.inf.modelling.pls.pls.PLSPackage#getProductionLineModel()
@@ -24,19 +25,35 @@ import org.eclipse.emf.ecore.EObject;
  */
 public interface ProductionLineModel extends EObject {
 	/**
-	 * Returns the value of the '<em><b>Elements</b></em>' containment reference list.
-	 * The list contents are of type {@link uk.ac.kcl.inf.modelling.pls.pls.NamedElement}.
+	 * Returns the value of the '<em><b>Machines</b></em>' containment reference list.
+	 * The list contents are of type {@link uk.ac.kcl.inf.modelling.pls.pls.Machine}.
 	 * <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Elements</em>' containment reference list isn't clear,
+	 * If the meaning of the '<em>Machines</em>' containment reference list isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Elements</em>' containment reference list.
-	 * @see uk.ac.kcl.inf.modelling.pls.pls.PLSPackage#getProductionLineModel_Elements()
+	 * @return the value of the '<em>Machines</em>' containment reference list.
+	 * @see uk.ac.kcl.inf.modelling.pls.pls.PLSPackage#getProductionLineModel_Machines()
 	 * @model containment="true"
 	 * @generated
 	 */
-	EList<NamedElement> getElements();
+	EList<Machine> getMachines();
+
+	/**
+	 * Returns the value of the '<em><b>Containers</b></em>' containment reference list.
+	 * The list contents are of type {@link uk.ac.kcl.inf.modelling.pls.pls.Container}.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Containers</em>' containment reference list isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Containers</em>' containment reference list.
+	 * @see uk.ac.kcl.inf.modelling.pls.pls.PLSPackage#getProductionLineModel_Containers()
+	 * @model containment="true"
+	 * @generated
+	 */
+	EList<Container> getContainers();
 
 } // ProductionLineModel

--- a/uk.ac.kcl.inf.modelling.pls.model/src-gen/uk/ac/kcl/inf/modelling/pls/pls/impl/ContainerImpl.java
+++ b/uk.ac.kcl.inf.modelling.pls.model/src-gen/uk/ac/kcl/inf/modelling/pls/pls/impl/ContainerImpl.java
@@ -4,12 +4,14 @@ package uk.ac.kcl.inf.modelling.pls.pls.impl;
 
 import java.util.Collection;
 
+import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.common.util.EList;
 
 import org.eclipse.emf.ecore.EClass;
 
-import org.eclipse.emf.ecore.util.EObjectResolvingEList;
-
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.util.EObjectContainmentEList;
+import org.eclipse.emf.ecore.util.InternalEList;
 import uk.ac.kcl.inf.modelling.pls.pls.PLSPackage;
 import uk.ac.kcl.inf.modelling.pls.pls.Part;
 
@@ -28,7 +30,7 @@ import uk.ac.kcl.inf.modelling.pls.pls.Part;
  */
 public class ContainerImpl extends NamedElementImpl implements uk.ac.kcl.inf.modelling.pls.pls.Container {
 	/**
-	 * The cached value of the '{@link #getParts() <em>Parts</em>}' reference list.
+	 * The cached value of the '{@link #getParts() <em>Parts</em>}' containment reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @see #getParts()
@@ -63,9 +65,23 @@ public class ContainerImpl extends NamedElementImpl implements uk.ac.kcl.inf.mod
 	 */
 	public EList<Part> getParts() {
 		if (parts == null) {
-			parts = new EObjectResolvingEList<Part>(Part.class, this, PLSPackage.CONTAINER__PARTS);
+			parts = new EObjectContainmentEList<Part>(Part.class, this, PLSPackage.CONTAINER__PARTS);
 		}
 		return parts;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
+		switch (featureID) {
+		case PLSPackage.CONTAINER__PARTS:
+			return ((InternalEList<?>) getParts()).basicRemove(otherEnd, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
 	}
 
 	/**

--- a/uk.ac.kcl.inf.modelling.pls.model/src-gen/uk/ac/kcl/inf/modelling/pls/pls/impl/NamedElementImpl.java
+++ b/uk.ac.kcl.inf.modelling.pls.model/src-gen/uk/ac/kcl/inf/modelling/pls/pls/impl/NamedElementImpl.java
@@ -154,7 +154,7 @@ public abstract class NamedElementImpl extends MinimalEObjectImpl.Container impl
 		if (eIsProxy())
 			return super.toString();
 
-		StringBuffer result = new StringBuffer(super.toString());
+		StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (name: ");
 		result.append(name);
 		result.append(')');

--- a/uk.ac.kcl.inf.modelling.pls.model/src-gen/uk/ac/kcl/inf/modelling/pls/pls/impl/PLSPackageImpl.java
+++ b/uk.ac.kcl.inf.modelling.pls.model/src-gen/uk/ac/kcl/inf/modelling/pls/pls/impl/PLSPackageImpl.java
@@ -166,7 +166,7 @@ public class PLSPackageImpl extends EPackageImpl implements PLSPackage {
 
 	/**
 	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
-	 * 
+	 *
 	 * <p>This method is used to initialize {@link PLSPackage#eINSTANCE} when that field is accessed.
 	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
 	 * <!-- begin-user-doc -->
@@ -181,9 +181,10 @@ public class PLSPackageImpl extends EPackageImpl implements PLSPackage {
 			return (PLSPackage) EPackage.Registry.INSTANCE.getEPackage(PLSPackage.eNS_URI);
 
 		// Obtain or create and register package
-		PLSPackageImpl thePLSPackage = (PLSPackageImpl) (EPackage.Registry.INSTANCE
-				.get(eNS_URI) instanceof PLSPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI)
-						: new PLSPackageImpl());
+		Object registeredPLSPackage = EPackage.Registry.INSTANCE.get(eNS_URI);
+		PLSPackageImpl thePLSPackage = registeredPLSPackage instanceof PLSPackageImpl
+				? (PLSPackageImpl) registeredPLSPackage
+				: new PLSPackageImpl();
 
 		isInited = true;
 
@@ -215,8 +216,17 @@ public class PLSPackageImpl extends EPackageImpl implements PLSPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EReference getProductionLineModel_Elements() {
+	public EReference getProductionLineModel_Machines() {
 		return (EReference) productionLineModelEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EReference getProductionLineModel_Containers() {
+		return (EReference) productionLineModelEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
@@ -420,7 +430,8 @@ public class PLSPackageImpl extends EPackageImpl implements PLSPackage {
 
 		// Create classes and their features
 		productionLineModelEClass = createEClass(PRODUCTION_LINE_MODEL);
-		createEReference(productionLineModelEClass, PRODUCTION_LINE_MODEL__ELEMENTS);
+		createEReference(productionLineModelEClass, PRODUCTION_LINE_MODEL__MACHINES);
+		createEReference(productionLineModelEClass, PRODUCTION_LINE_MODEL__CONTAINERS);
 
 		machineEClass = createEClass(MACHINE);
 		createEReference(machineEClass, MACHINE__OUT);
@@ -502,7 +513,10 @@ public class PLSPackageImpl extends EPackageImpl implements PLSPackage {
 		// Initialize classes, features, and operations; add parameters
 		initEClass(productionLineModelEClass, ProductionLineModel.class, "ProductionLineModel", !IS_ABSTRACT,
 				!IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getProductionLineModel_Elements(), this.getNamedElement(), null, "elements", null, 0, -1,
+		initEReference(getProductionLineModel_Machines(), this.getMachine(), null, "machines", null, 0, -1,
+				ProductionLineModel.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
+				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getProductionLineModel_Containers(), this.getContainer(), null, "containers", null, 0, -1,
 				ProductionLineModel.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
 				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
@@ -518,7 +532,7 @@ public class PLSPackageImpl extends EPackageImpl implements PLSPackage {
 				!IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getContainer_Parts(), this.getPart(), null, "parts", null, 0, -1,
 				uk.ac.kcl.inf.modelling.pls.pls.Container.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
-				!IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+				IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(partEClass, Part.class, "Part", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
@@ -571,7 +585,6 @@ public class PLSPackageImpl extends EPackageImpl implements PLSPackage {
 	 */
 	protected void createAspectAnnotations() {
 		String source = "aspect";
-		addAnnotation(getProductionLineModel_Elements(), source, new String[] {});
 		addAnnotation(getContainer_Parts(), source, new String[] {});
 		addAnnotation(partEClass, source, new String[] {});
 		addAnnotation(hammerEClass, source, new String[] {});

--- a/uk.ac.kcl.inf.modelling.pls.model/src-gen/uk/ac/kcl/inf/modelling/pls/pls/impl/ProductionLineModelImpl.java
+++ b/uk.ac.kcl.inf.modelling.pls.model/src-gen/uk/ac/kcl/inf/modelling/pls/pls/impl/ProductionLineModelImpl.java
@@ -16,7 +16,7 @@ import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 import org.eclipse.emf.ecore.util.EObjectContainmentEList;
 import org.eclipse.emf.ecore.util.InternalEList;
 
-import uk.ac.kcl.inf.modelling.pls.pls.NamedElement;
+import uk.ac.kcl.inf.modelling.pls.pls.Machine;
 import uk.ac.kcl.inf.modelling.pls.pls.PLSPackage;
 import uk.ac.kcl.inf.modelling.pls.pls.ProductionLineModel;
 
@@ -28,21 +28,31 @@ import uk.ac.kcl.inf.modelling.pls.pls.ProductionLineModel;
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link uk.ac.kcl.inf.modelling.pls.pls.impl.ProductionLineModelImpl#getElements <em>Elements</em>}</li>
+ *   <li>{@link uk.ac.kcl.inf.modelling.pls.pls.impl.ProductionLineModelImpl#getMachines <em>Machines</em>}</li>
+ *   <li>{@link uk.ac.kcl.inf.modelling.pls.pls.impl.ProductionLineModelImpl#getContainers <em>Containers</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class ProductionLineModelImpl extends MinimalEObjectImpl.Container implements ProductionLineModel {
 	/**
-	 * The cached value of the '{@link #getElements() <em>Elements</em>}' containment reference list.
+	 * The cached value of the '{@link #getMachines() <em>Machines</em>}' containment reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #getElements()
+	 * @see #getMachines()
 	 * @generated
 	 * @ordered
 	 */
-	protected EList<NamedElement> elements;
+	protected EList<Machine> machines;
+	/**
+	 * The cached value of the '{@link #getContainers() <em>Containers</em>}' containment reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getContainers()
+	 * @generated
+	 * @ordered
+	 */
+	protected EList<uk.ac.kcl.inf.modelling.pls.pls.Container> containers;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -68,12 +78,26 @@ public class ProductionLineModelImpl extends MinimalEObjectImpl.Container implem
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EList<NamedElement> getElements() {
-		if (elements == null) {
-			elements = new EObjectContainmentEList<NamedElement>(NamedElement.class, this,
-					PLSPackage.PRODUCTION_LINE_MODEL__ELEMENTS);
+	public EList<Machine> getMachines() {
+		if (machines == null) {
+			machines = new EObjectContainmentEList<Machine>(Machine.class, this,
+					PLSPackage.PRODUCTION_LINE_MODEL__MACHINES);
 		}
-		return elements;
+		return machines;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EList<uk.ac.kcl.inf.modelling.pls.pls.Container> getContainers() {
+		if (containers == null) {
+			containers = new EObjectContainmentEList<uk.ac.kcl.inf.modelling.pls.pls.Container>(
+					uk.ac.kcl.inf.modelling.pls.pls.Container.class, this,
+					PLSPackage.PRODUCTION_LINE_MODEL__CONTAINERS);
+		}
+		return containers;
 	}
 
 	/**
@@ -84,8 +108,10 @@ public class ProductionLineModelImpl extends MinimalEObjectImpl.Container implem
 	@Override
 	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
 		switch (featureID) {
-		case PLSPackage.PRODUCTION_LINE_MODEL__ELEMENTS:
-			return ((InternalEList<?>) getElements()).basicRemove(otherEnd, msgs);
+		case PLSPackage.PRODUCTION_LINE_MODEL__MACHINES:
+			return ((InternalEList<?>) getMachines()).basicRemove(otherEnd, msgs);
+		case PLSPackage.PRODUCTION_LINE_MODEL__CONTAINERS:
+			return ((InternalEList<?>) getContainers()).basicRemove(otherEnd, msgs);
 		}
 		return super.eInverseRemove(otherEnd, featureID, msgs);
 	}
@@ -98,8 +124,10 @@ public class ProductionLineModelImpl extends MinimalEObjectImpl.Container implem
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
-		case PLSPackage.PRODUCTION_LINE_MODEL__ELEMENTS:
-			return getElements();
+		case PLSPackage.PRODUCTION_LINE_MODEL__MACHINES:
+			return getMachines();
+		case PLSPackage.PRODUCTION_LINE_MODEL__CONTAINERS:
+			return getContainers();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -113,9 +141,13 @@ public class ProductionLineModelImpl extends MinimalEObjectImpl.Container implem
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
-		case PLSPackage.PRODUCTION_LINE_MODEL__ELEMENTS:
-			getElements().clear();
-			getElements().addAll((Collection<? extends NamedElement>) newValue);
+		case PLSPackage.PRODUCTION_LINE_MODEL__MACHINES:
+			getMachines().clear();
+			getMachines().addAll((Collection<? extends Machine>) newValue);
+			return;
+		case PLSPackage.PRODUCTION_LINE_MODEL__CONTAINERS:
+			getContainers().clear();
+			getContainers().addAll((Collection<? extends uk.ac.kcl.inf.modelling.pls.pls.Container>) newValue);
 			return;
 		}
 		super.eSet(featureID, newValue);
@@ -129,8 +161,11 @@ public class ProductionLineModelImpl extends MinimalEObjectImpl.Container implem
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
-		case PLSPackage.PRODUCTION_LINE_MODEL__ELEMENTS:
-			getElements().clear();
+		case PLSPackage.PRODUCTION_LINE_MODEL__MACHINES:
+			getMachines().clear();
+			return;
+		case PLSPackage.PRODUCTION_LINE_MODEL__CONTAINERS:
+			getContainers().clear();
 			return;
 		}
 		super.eUnset(featureID);
@@ -144,8 +179,10 @@ public class ProductionLineModelImpl extends MinimalEObjectImpl.Container implem
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
-		case PLSPackage.PRODUCTION_LINE_MODEL__ELEMENTS:
-			return elements != null && !elements.isEmpty();
+		case PLSPackage.PRODUCTION_LINE_MODEL__MACHINES:
+			return machines != null && !machines.isEmpty();
+		case PLSPackage.PRODUCTION_LINE_MODEL__CONTAINERS:
+			return containers != null && !containers.isEmpty();
 		}
 		return super.eIsSet(featureID);
 	}


### PR DESCRIPTION
A better meta-model, to make GEMOC's life a little easier.

In this, I have broken the `elements` top-level containment reference into more specific containment references, so that dynamic and static parts of the model are kept in different references. This will make GEMOC's life easier, especially wrt to the omniscient debugger's handling of states.